### PR TITLE
fix: update hooks action to take arguments

### DIFF
--- a/src/hooks/api.js
+++ b/src/hooks/api.js
@@ -13,8 +13,8 @@ const { useMakeNetworkRequest } = reduxHooks;
 
 export const useNetworkRequest = (action, args) => {
   const makeNetworkRequest = useMakeNetworkRequest();
-  return () => makeNetworkRequest({
-    promise: action(),
+  return (...actionsArgs) => makeNetworkRequest({
+    promise: action(actionsArgs),
     ...args,
   });
 };
@@ -34,19 +34,19 @@ export const useInitializeApp = () => {
 export const useNewEntitlementEnrollment = (cardId) => {
   const { uuid } = reduxHooks.useCardEntitlementData(cardId);
   const onSuccess = module.useInitializeApp();
-  return (selection) => module.useNetworkRequest(
-    () => api.updateEntitlementEnrollment({ uuid, courseId: selection }),
+  return module.useNetworkRequest(
+    (selection) => api.updateEntitlementEnrollment({ uuid, courseId: selection }),
     { onSuccess, requestKey: RequestKeys.newEntitlementEnrollment },
-  )();
+  );
 };
 
 export const useSwitchEntitlementEnrollment = (cardId) => {
   const { uuid } = reduxHooks.useCardEntitlementData(cardId);
   const onSuccess = module.useInitializeApp();
-  return (selection) => module.useNetworkRequest(
-    () => api.updateEntitlementEnrollment({ uuid, courseId: selection }),
+  return module.useNetworkRequest(
+    (selection) => api.updateEntitlementEnrollment({ uuid, courseId: selection }),
     { onSuccess, requestKey: RequestKeys.switchEntitlementSession },
-  )();
+  );
 };
 
 export const useLeaveEntitlementSession = (cardId) => {
@@ -68,10 +68,10 @@ export const useUnenrollFromCourse = (cardId) => {
 
 export const useMasqueradeAs = () => {
   const loadData = reduxHooks.useLoadData();
-  return (user) => module.useNetworkRequest(
-    () => api.initializeList({ user }),
+  return module.useNetworkRequest(
+    (user) => api.initializeList({ user }),
     { onSuccess: ({ data }) => loadData(data), requestKey: RequestKeys.masquerade },
-  )();
+  );
 };
 
 export const useClearMasquerade = () => {
@@ -85,10 +85,10 @@ export const useClearMasquerade = () => {
 
 export const useUpdateEmailSettings = (cardId) => {
   const { courseId } = reduxHooks.useCardCourseRunData(cardId);
-  return (enable) => module.useNetworkRequest(
-    () => api.updateEmailSettings({ courseId, enable }),
+  return module.useNetworkRequest(
+    (enable) => api.updateEmailSettings({ courseId, enable }),
     { requestKey: RequestKeys.updateEmailSettings },
-  )();
+  );
 };
 
 export const useSendConfirmEmail = () => {

--- a/src/hooks/api.test.js
+++ b/src/hooks/api.test.js
@@ -120,7 +120,7 @@ describe('api hooks', () => {
       describe('useNewEntitlementEnrollment', () => {
         beforeEach(() => {
           hook = apiHooks.useNewEntitlementEnrollment(cardId);
-          out = hook(selection);
+          out = hook();
         });
         testInitialization();
         testArgs(RequestKeys.newEntitlementEnrollment);
@@ -136,7 +136,7 @@ describe('api hooks', () => {
       describe('useSwitchEntitlementEnrollment', () => {
         beforeEach(() => {
           hook = apiHooks.useSwitchEntitlementEnrollment(cardId);
-          out = hook(selection);
+          out = hook();
         });
         testInitialization();
         testArgs(RequestKeys.switchEntitlementSession);
@@ -152,7 +152,7 @@ describe('api hooks', () => {
       describe('useLeaveEntitlementSession', () => {
         beforeEach(() => {
           hook = apiHooks.useLeaveEntitlementSession(cardId);
-          out = hook(selection);
+          out = hook();
         });
         testInitialization();
         testArgs(RequestKeys.leaveEntitlementSession);
@@ -182,14 +182,14 @@ describe('api hooks', () => {
     describe('useMasqueradeAs', () => {
       beforeEach(() => {
         hook = apiHooks.useMasqueradeAs(cardId);
-        out = hook(user);
+        out = hook();
       });
       it('initializes load data hook', () => {
         expect(reduxHooks.useLoadData).toHaveBeenCalledWith();
       });
       testRequestKey(RequestKeys.masquerade);
       it('calls initializeList api method', () => {
-        out.action();
+        out.action(user);
         expect(api.initializeList).toHaveBeenCalledWith({ user });
       });
       it('loads data on success', () => {
@@ -220,12 +220,12 @@ describe('api hooks', () => {
       const enable = 'test-enable';
       beforeEach(() => {
         hook = apiHooks.useUpdateEmailSettings(cardId);
-        out = hook(enable);
+        out = hook();
       });
       testInitCardHook(reduxKeys.useCardCourseRunData);
       testRequestKey(RequestKeys.updateEmailSettings);
       it('calls updateEmailSettings api method on call', () => {
-        out.action();
+        out.action(enable);
         expect(api.updateEmailSettings).toHaveBeenCalledWith({ courseId, enable });
       });
     });


### PR DESCRIPTION
What get fix:
- Masquerade
- Update entitlement
- update email settings

What change:
- let `action` function take arguments

Why:
- too many functional pointer made react think dispatch was being call outside of the component body
- not the fault on our part of the code, it is the functional hell moment
