### PR TITLE
feat: add event for filtering

### DIFF
--- a/src/containers/CourseFilterControls/ActiveCourseFilters.jsx
+++ b/src/containers/CourseFilterControls/ActiveCourseFilters.jsx
@@ -18,7 +18,6 @@ export const ActiveCourseFilters = ({
     <div id="course-list-active-filters">
       {filters.map(filter => (
         <Chip
-          variant="primary"
           key={filter}
           iconAfter={CloseSmall}
           onClick={handleRemoveFilter(filter)}

--- a/src/containers/CourseFilterControls/CourseFilterControls.jsx
+++ b/src/containers/CourseFilterControls/CourseFilterControls.jsx
@@ -40,6 +40,7 @@ export const CourseFilterControls = ({
     handleFilterChange,
     handleSortChange,
   } = useCourseFilterControlsData({
+    filters,
     setFilters,
     setSortBy,
   });

--- a/src/containers/CourseFilterControls/__snapshots__/ActiveCourseFilters.test.jsx.snap
+++ b/src/containers/CourseFilterControls/__snapshots__/ActiveCourseFilters.test.jsx.snap
@@ -6,31 +6,26 @@ exports[`ActiveCourseFilters snapshot renders 1`] = `
 >
   <Chip
     key="inProgress"
-    variant="primary"
   >
     In-Progress
   </Chip>
   <Chip
     key="notStarted"
-    variant="primary"
   >
     Not Started
   </Chip>
   <Chip
     key="done"
-    variant="primary"
   >
     Done
   </Chip>
   <Chip
     key="notEnrolled"
-    variant="primary"
   >
     Not Enrolled
   </Chip>
   <Chip
     key="upgraded"
-    variant="primary"
   >
     Upgraded
   </Chip>

--- a/src/containers/CourseFilterControls/hooks.js
+++ b/src/containers/CourseFilterControls/hooks.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useToggle } from '@edx/paragon';
 
 import { StrictDict } from 'utils';
+import track from 'tracking';
 
 import * as module from './hooks';
 
@@ -10,10 +11,11 @@ export const state = StrictDict({
 });
 
 export const useCourseFilterControlsData = ({
+  filters,
   setFilters,
   setSortBy,
 }) => {
-  const [isOpen, open, close] = useToggle(false);
+  const [isOpen, toggleOpen, toggleClose] = useToggle(false);
   const [target, setTarget] = module.state.target(null);
   const handleFilterChange = ({ target: { checked, value } }) => {
     const update = checked ? setFilters.add : setFilters.remove;
@@ -22,6 +24,17 @@ export const useCourseFilterControlsData = ({
   const handleSortChange = ({ target: { value } }) => {
     setSortBy(value);
   };
+
+  const open = () => {
+    track.filter.filterClicked();
+    toggleOpen();
+  };
+
+  const close = () => {
+    track.filter.filterOptionSelected(filters);
+    toggleClose();
+  };
+
   return {
     isOpen,
     open,

--- a/src/containers/CourseFilterControls/hooks.test.js
+++ b/src/containers/CourseFilterControls/hooks.test.js
@@ -1,13 +1,22 @@
 import { useToggle } from '@edx/paragon';
 
 import { MockUseState } from 'testUtils';
+import track from 'tracking';
 
 import * as hooks from './hooks';
+
+jest.mock('tracking', () => ({
+  filter: {
+    filterClicked: jest.fn(),
+    filterOptionSelected: jest.fn(),
+  },
+}));
 
 const state = new MockUseState(hooks);
 
 describe('CourseFilterControls hooks', () => {
   let out;
+  const filters = ['a', 'b', 'c'];
   const setSortBy = jest.fn();
   const setFilters = {
     add: jest.fn(),
@@ -27,6 +36,7 @@ describe('CourseFilterControls hooks', () => {
       useToggle.mockReturnValueOnce([false, toggleOpen, toggleClose]);
       state.mock();
       out = hooks.useCourseFilterControlsData({
+        filters,
         setFilters,
         setSortBy,
       });
@@ -35,9 +45,19 @@ describe('CourseFilterControls hooks', () => {
 
     test('default state', () => {
       expect(out.isOpen).toEqual(false);
-      expect(out.open).toEqual(toggleOpen);
-      expect(out.close).toEqual(toggleClose);
       expect(out.target).toEqual(state.stateVals.target);
+    });
+
+    test('open calls toggleOpen and track.filter.filterClicked', () => {
+      out.open();
+      expect(toggleOpen).toHaveBeenCalled();
+      expect(track.filter.filterClicked).toHaveBeenCalled();
+    });
+
+    test('close calls toggleClose and track.filter.filterOptionSelected', () => {
+      out.close();
+      expect(toggleClose).toHaveBeenCalled();
+      expect(track.filter.filterOptionSelected).toHaveBeenCalledWith(filters);
     });
 
     test('isOpen is true when target is set', () => {
@@ -45,6 +65,7 @@ describe('CourseFilterControls hooks', () => {
       expect(out.target).toEqual(null);
       state.mockVal(state.keys.target, 'foo');
       out = hooks.useCourseFilterControlsData({
+        filters,
         setFilters,
         setSortBy,
       });

--- a/src/tracking/constants.js
+++ b/src/tracking/constants.js
@@ -6,6 +6,7 @@ export const categories = StrictDict({
   userEngagement: 'user-engagement',
   searchButton: 'search_button',
   credit: 'credit',
+  filter: 'filter',
 });
 
 export const events = StrictDict({
@@ -50,6 +51,8 @@ export const eventNames = StrictDict({
   enterpriseDashboardModalClosed: `${learnerPortal}.closed`,
   findCoursesClicked: 'edx.bi.dashboard.find_courses_button.clicked',
   purchaseCredit: 'edx.bi.credit.clicked_purchase_credit',
+  filterClicked: 'course-dashboard.filter.clicked',
+  filterOptionSelected: 'course-dashboard.filter_option.selected',
 });
 
 export const linkNames = StrictDict({

--- a/src/tracking/index.js
+++ b/src/tracking/index.js
@@ -5,6 +5,7 @@ import enterpriseDashboard from './trackers/enterpriseDashboard';
 import entitlements from './trackers/entitlements';
 import socialShare from './trackers/socialShare';
 import findCourses from './trackers/findCourses';
+import filter from './trackers/filter';
 
 export default {
   course,
@@ -14,4 +15,5 @@ export default {
   entitlements,
   socialShare,
   findCourses,
+  filter,
 };

--- a/src/tracking/trackers/filter.js
+++ b/src/tracking/trackers/filter.js
@@ -1,0 +1,21 @@
+import { createEventTracker } from 'data/services/segment/utils';
+import { categories, eventNames } from '../constants';
+
+export const filterClicked = () => createEventTracker(
+  eventNames.filterClicked,
+  { category: categories.filter },
+)();
+
+export const filterOptionSelected = (filters = []) => createEventTracker(
+  eventNames.filterOptionSelected,
+  {
+    category: categories.filter,
+    // make sure to clone before sorting
+    filters: [...filters].sort(),
+  },
+)();
+
+export default {
+  filterClicked,
+  filterOptionSelected,
+};

--- a/src/tracking/trackers/filter.test.js
+++ b/src/tracking/trackers/filter.test.js
@@ -1,0 +1,45 @@
+import { createEventTracker } from 'data/services/segment/utils';
+import { eventNames, categories } from '../constants';
+import * as trackers from './filter';
+
+jest.mock('data/services/segment/utils', () => ({
+  createEventTracker: jest.fn(() => () => {}),
+}));
+
+const filters = ['test-filter-2', 'test-filter-1'];
+
+describe('filter trackers', () => {
+  afterEach(() => createEventTracker.mockClear());
+  test('filter clicked event', () => {
+    trackers.filterClicked();
+    expect(createEventTracker).toHaveBeenCalledWith(eventNames.filterClicked, {
+      category: categories.filter,
+    });
+  });
+
+  describe('filter option selected event', () => {
+    test('with filter', () => {
+      trackers.filterOptionSelected(filters);
+      expect(createEventTracker).toHaveBeenCalledWith(
+        eventNames.filterOptionSelected,
+        {
+          category: categories.filter,
+          filters: [filters[1], filters[0]],
+        },
+      );
+      // make sure filter isn't using the original array
+      expect(createEventTracker.mock.calls[0][1].filters).not.toBe(filters);
+    });
+
+    test('without filter', () => {
+      trackers.filterOptionSelected();
+      expect(createEventTracker).toHaveBeenCalledWith(
+        eventNames.filterOptionSelected,
+        {
+          category: categories.filter,
+          filters: [],
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/AU-1042

What changed:
- add event to filtering when the refine button click and the filter menu close
- on refine button click the event name will be 
  ```js
  analytics.track('course-dashboard.filter.clicked', {
    app_name: 'learner-home',
    category: 'filter'
  });
  ```
- on filter close the event will be
  ```js
  analytics.track('course-dashboard.filter_option.selected', {
    app_name: 'learner-home',
    category: 'filter',
    filters: [
      'done',
      'notStarted'
    ]
  });
  ```

How to test:
- You need access to segment and edx-internal

1. Add `SEGMENT_KEY` from `edx-internal` to `.env.development` file
2. Restart or run applicaiton `npm start`
3. Click on refine button and close it.
4. You should see event like above in segment learner home live debug

Goal:
1. `course-dashboard.filter.clicked` visibility of the button. Is the users can find the button?
2. `course-dashboard.filter_option.selected` with options. What is the popular option/options-set the user use?
3. `course-dashboard.filter_option.selected` with empty options. Is the filtering is useless to the user?

