### PR TITLE
chore: make related program folder bolder

### DIFF
--- a/src/containers/CourseCard/components/CourseCardBanners/RelatedProgramsBanner/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardBanners/RelatedProgramsBanner/__snapshots__/index.test.jsx.snap
@@ -6,7 +6,11 @@ exports[`RelatedProgramsBanner render with programs 1`] = `
   icon={[MockFunction icons.Program]}
   variant="info"
 >
-  Related Programs: 
+  <span
+    className="font-weight-bolder"
+  >
+    Related Programs: 
+  </span>
   <ProgramsList
     programs={
       Array [

--- a/src/containers/CourseCard/components/CourseCardBanners/RelatedProgramsBanner/index.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/RelatedProgramsBanner/index.jsx
@@ -21,7 +21,7 @@ export const RelatedProgramsBanner = ({ cardId }) => {
         icon={Program}
         className="bg-white border-top border-bottom mb-0 related-programs-banner"
       >
-        {formatMessage(messages.relatedPrograms)}
+        <span className="font-weight-bolder">{formatMessage(messages.relatedPrograms)}</span>
         <ProgramList programs={programData.list} />
       </Banner>
     )


### PR DESCRIPTION
What changed:
- make `related program` text bold.

From this:
![Screenshot 2023-02-14 at 12 37 20 PM](https://user-images.githubusercontent.com/83240113/218815005-14bfba9d-0dc9-4bbf-b915-7897587a0969.png)
To this:
![Screenshot 2023-02-14 at 12 35 17 PM](https://user-images.githubusercontent.com/83240113/218814971-e1e1f5a4-0c0b-4e9e-97eb-363609d56824.png)