### PR TITLE
fix: disable view button on expired access

### DIFF
--- a/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.jsx
@@ -11,15 +11,17 @@ import messages from './messages';
 export const ViewCourseButton = ({ cardId }) => {
   const { formatMessage } = useIntl();
   const { homeUrl } = reduxHooks.useCardCourseRunData(cardId);
-  const { hasAccess } = reduxHooks.useCardEnrollmentData(cardId);
+  const { hasAccess, isAudit, isAuditAccessExpired } = reduxHooks.useCardEnrollmentData(cardId);
   const handleClick = reduxHooks.useTrackCourseEvent(
     track.course.enterCourseClicked,
     cardId,
     homeUrl,
   );
+  // disabled on no access or (is audit track but audit access was expired)
+  const disabledViewCourseButton = !hasAccess || (isAudit && isAuditAccessExpired);
   return (
     <ActionButton
-      disabled={!hasAccess}
+      disabled={disabledViewCourseButton}
       as="a"
       href="#"
       onClick={handleClick}

--- a/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.test.jsx
@@ -29,12 +29,14 @@ const homeUrl = 'homeUrl';
 
 const createWrapper = ({
   hasAccess = false,
+  isAudit = false,
+  isAuditAccessExpired = false,
   isEntitlement = false,
   isExpired = false,
   propsOveride = {},
 }) => {
   reduxHooks.useCardCourseRunData.mockReturnValue({ homeUrl });
-  reduxHooks.useCardEnrollmentData.mockReturnValueOnce({ hasAccess });
+  reduxHooks.useCardEnrollmentData.mockReturnValueOnce({ hasAccess, isAudit, isAuditAccessExpired });
   reduxHooks.useCardEntitlementData.mockReturnValueOnce({ isEntitlement, isExpired });
   return shallow(<ViewCourseButton {...defaultProps} {...propsOveride} />);
 };
@@ -57,6 +59,10 @@ describe('ViewCourseButton', () => {
     test('link is enabled', () => {
       expect(wrapper.prop(htmlProps.disabled)).toEqual(false);
     });
+    test('link is disabled when audit access is expired', () => {
+      wrapper = createWrapper({ hasAccess: true, isAudit: true, isAuditAccessExpired: true });
+      expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+    });
   });
   describe('learner does not have access to course', () => {
     beforeEach(() => {
@@ -72,7 +78,7 @@ describe('ViewCourseButton', () => {
         homeUrl,
       ));
     });
-    test('link is enabled', () => {
+    test('link is disabled', () => {
       expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
     });
   });


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/AU-1066
what change:
- disable view button on audit expired access
- disable link is no clickable and lead to undefined page

![Screenshot 2023-02-16 at 2 21 09 PM](https://user-images.githubusercontent.com/83240113/219467019-5436876d-9275-4799-b7bb-303964a76da0.png)
![Screenshot 2023-02-16 at 2 20 42 PM](https://user-images.githubusercontent.com/83240113/219467022-bfbf492f-f484-4266-b5fd-3844b11d24f5.png)

