### PR TITLE
fix: credit cors error

### DIFF
--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -23,8 +23,8 @@ export const learningMfeUrl = (url) => updateUrl(configuration.LEARNING_BASE_URL
 // static view url
 const programsUrl = baseAppUrl('/dashboard/programs');
 
-export const creditPurchaseUrl = (courseId) => `${ecommerceUrl}/credit/checkout/${courseId}`;
-export const creditRequestUrl = (providerId) => `${api}/credit/v1/providers/${providerId}/request`;
+export const creditPurchaseUrl = (courseId) => `${ecommerceUrl}/credit/checkout/${courseId}/`;
+export const creditRequestUrl = (providerId) => `${api}/credit/v1/providers/${providerId}/request/`;
 
 export default StrictDict({
   api,


### PR DESCRIPTION
Why this caused the error?
- the correct url ended with `/`
- lms try to redirect the incorrect to end with `/`
- cloudflare block the redirect and throw a CORS error.

This may be a one time thing, but we might need to review our cloudflare rewrite policy for this.