### PR TITLE
refactor: update API endpoint

### DIFF
--- a/src/widgets/RecommendationsPanel/api.js
+++ b/src/widgets/RecommendationsPanel/api.js
@@ -2,7 +2,7 @@ import { StrictDict } from 'utils';
 import { get, stringifyUrl } from 'data/services/lms/utils';
 import urls from 'data/services/lms/urls';
 
-export const fetchUrl = `${urls.api}/learner_home/recommendation/courses/`;
+export const fetchUrl = `${urls.api}/learner_recommendations/courses/`;
 export const apiKeys = StrictDict({ user: 'user' });
 
 const fetchRecommendedCourses = () => get(stringifyUrl(fetchUrl));


### PR DESCRIPTION
Point API call to a new endpoint.

We are refactoring our recommendation code to reduce redundancy. We moved our recommendation API from `learner_home` and `learner_dashboard` to `learner_recommendations` that's why we need to point API call on a new endpoint.

**Backend PR:**
https://github.com/openedx/edx-platform/pull/31975

After deploying this, we will remove the legacy [code](https://github.com/openedx/edx-platform/pull/31990) from the platform.


[Ticket](https://2u-internal.atlassian.net/jira/software/c/projects/VAN/boards/659?modal=detail&selectedIssue=VAN-1310)