### PR TITLE
Bw/fix network args

### DIFF
--- a/src/containers/LearnerDashboardHeader/AuthenticatedUserDropdown.test.jsx
+++ b/src/containers/LearnerDashboardHeader/AuthenticatedUserDropdown.test.jsx
@@ -1,9 +1,13 @@
 import { shallow } from 'enzyme';
+import { getConfig } from '@edx/frontend-platform';
 
 import { reduxHooks } from 'hooks';
 import { AuthenticatedUserDropdown } from './AuthenticatedUserDropdown';
 import { useIsCollapsed } from './hooks';
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+}));
 jest.mock('@edx/frontend-platform/react', () => ({
   AppContext: {
     authenticatedUser: {
@@ -23,6 +27,15 @@ jest.mock('containers/LearnerDashboardHeader/hooks', () => ({
   useIsCollapsed: jest.fn(),
   findCoursesNavDropdownClicked: (href) => jest.fn().mockName(`findCoursesNavDropdownClicked('${href}')`),
 }));
+
+const config = {
+  ACCOUNT_PROFILE_URL: 'http://account-profile-url.test',
+  ACCOUNT_SETTINGS_URL: 'http://account-settings-url.test',
+  LOGOUT_URL: 'http://logout-url.test',
+  ORDER_HISTORY_URL: 'http://order-history-url.test',
+  SUPPORT_URL: 'http://localhost:18000/support',
+};
+getConfig.mockReturnValue(config);
 
 describe('AuthenticatedUserDropdown', () => {
   const props = {

--- a/src/containers/LearnerDashboardHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
@@ -62,13 +62,18 @@ exports[`AuthenticatedUserDropdown snapshots with enterprise dashboard 1`] = `
       Account
     </Dropdown.Item>
     <Dropdown.Item
+      href="http://order-history-url.test"
+    >
+      Order History
+    </Dropdown.Item>
+    <Dropdown.Item
       href="http://localhost:18000/support"
     >
       Help
     </Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item
-      href="http://localhost:18000/logout"
+      href="http://logout-url.test"
     >
       Sign Out
     </Dropdown.Item>
@@ -118,13 +123,18 @@ exports[`AuthenticatedUserDropdown snapshots without enterprise dashboard and ex
       Account
     </Dropdown.Item>
     <Dropdown.Item
+      href="http://order-history-url.test"
+    >
+      Order History
+    </Dropdown.Item>
+    <Dropdown.Item
       href="http://localhost:18000/support"
     >
       Help
     </Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item
-      href="http://localhost:18000/logout"
+      href="http://logout-url.test"
     >
       Sign Out
     </Dropdown.Item>

--- a/src/containers/LearnerDashboardHeaderVariant/ExpandedHeader/AuthenticatedUserDropdown.test.jsx
+++ b/src/containers/LearnerDashboardHeaderVariant/ExpandedHeader/AuthenticatedUserDropdown.test.jsx
@@ -1,10 +1,14 @@
 import { shallow } from 'enzyme';
 
 import { reduxHooks } from 'hooks';
+import { getConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';
 import { AuthenticatedUserDropdown } from './AuthenticatedUserDropdown';
 import { useIsCollapsed } from '../hooks';
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+}));
 jest.mock('@edx/frontend-platform/react', () => ({
   AppContext: {
     authenticatedUser: {
@@ -25,6 +29,15 @@ jest.mock('../hooks', () => ({
   useIsCollapsed: jest.fn(),
   findCoursesNavDropdownClicked: (href) => jest.fn().mockName(`findCoursesNavDropdownClicked('${href}')`),
 }));
+
+const config = {
+  ACCOUNT_PROFILE_URL: 'http://account-profile-url.test',
+  ACCOUNT_SETTINGS_URL: 'http://account-settings-url.test',
+  LOGOUT_URL: 'http://logout-url.test',
+  ORDER_HISTORY_URL: 'http://order-history-url.test',
+  SUPPORT_URL: 'http://localhost:18000/support',
+};
+getConfig.mockReturnValue(config);
 
 describe('AuthenticatedUserDropdown', () => {
   const defaultDashboardData = {

--- a/src/containers/LearnerDashboardHeaderVariant/ExpandedHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeaderVariant/ExpandedHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
@@ -52,9 +52,14 @@ exports[`AuthenticatedUserDropdown snapshots with enterprise dashboard 1`] = `
     >
       Account
     </Dropdown.Item>
+    <Dropdown.Item
+      href="http://order-history-url.test"
+    >
+      Order History
+    </Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item
-      href="http://localhost:18000/logout"
+      href="http://logout-url.test"
     >
       Sign Out
     </Dropdown.Item>
@@ -103,9 +108,14 @@ exports[`AuthenticatedUserDropdown snapshots without enterprise dashboard and ex
     >
       Account
     </Dropdown.Item>
+    <Dropdown.Item
+      href="http://order-history-url.test"
+    >
+      Order History
+    </Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item
-      href="http://localhost:18000/logout"
+      href="http://logout-url.test"
     >
       Sign Out
     </Dropdown.Item>

--- a/src/hooks/api.js
+++ b/src/hooks/api.js
@@ -14,7 +14,7 @@ const { useMakeNetworkRequest } = reduxHooks;
 export const useNetworkRequest = (action, args) => {
   const makeNetworkRequest = useMakeNetworkRequest();
   return (...actionsArgs) => makeNetworkRequest({
-    promise: action(actionsArgs),
+    promise: action(...actionsArgs),
     ...args,
   });
 };
@@ -43,8 +43,9 @@ export const useNewEntitlementEnrollment = (cardId) => {
 export const useSwitchEntitlementEnrollment = (cardId) => {
   const { uuid } = reduxHooks.useCardEntitlementData(cardId);
   const onSuccess = module.useInitializeApp();
+  const action = (selection) => api.updateEntitlementEnrollment({ uuid, courseId: selection });
   return module.useNetworkRequest(
-    (selection) => api.updateEntitlementEnrollment({ uuid, courseId: selection }),
+    action,
     { onSuccess, requestKey: RequestKeys.switchEntitlementSession },
   );
 };


### PR DESCRIPTION
Fix for email settings message always sending True.
Source was issue in network event actions, not spreading incoming args, and thus sending [`true`] instead of `true` as argument.

Need to test New/Update entitlements and MasqueradeAs after this fix.

JIRA: AU-1132