### PR TITLE
fix: noticeswrapper api response error

### DIFF
--- a/src/components/NoticesWrapper/hooks.js
+++ b/src/components/NoticesWrapper/hooks.js
@@ -21,9 +21,9 @@ export const useNoticesWrapperData = () => {
     if (getConfig().ENABLE_NOTICES) {
       getNotices({
         onLoad: (data) => {
-          if (data?.results?.length > 0) {
+          if (data?.data?.results?.length > 0) {
             setIsRedirected(true);
-            window.location.replace(`${data.results[0]}?next=${window.location.href}`);
+            window.location.replace(`${data.data.results[0]}?next=${window.location.href}`);
           }
         },
       });

--- a/src/components/NoticesWrapper/hooks.test.js
+++ b/src/components/NoticesWrapper/hooks.test.js
@@ -64,7 +64,7 @@ describe('NoticesWrapper hooks', () => {
             expect(getNotices).toHaveBeenCalled();
             const { onLoad } = getNotices.mock.calls[0][0];
             const target = 'url-target';
-            onLoad({ results: [target] });
+            onLoad({ data: { results: [target] } });
             expect(state.setState.isRedirected).toHaveBeenCalledWith(true);
             expect(window.location.replace).toHaveBeenCalledWith(
               `${target}?next=${window.location.href}`,


### PR DESCRIPTION
the response from the notices api is
`{data: {results: [a, b, c]} }`
but we were trying to read
`{results: [a, b, c]}`

fix