### PR TITLE
fix: account for `isLearnerPortalEnabled` when determining `hasAvailableDashboards`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "TZ=GMT fedx-scripts jest --coverage --passWithNoTests",
     "quality": "npm run lint-fix && npm run test",
     "watch-tests": "jest --watch",
+    "snapshot": "fedx-scripts jest --updateSnapshot",
     "prepare": "husky install"
   },
   "author": "edX",

--- a/src/containers/EnterpriseDashboardModal/__snapshots__/index.test.jsx.snap
+++ b/src/containers/EnterpriseDashboardModal/__snapshots__/index.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`EnterpriseDashboard snapshot 1`] = `
         onClick={[MockFunction useEnterpriseDashboardHook.handleCTAClick]}
         type="a"
       >
-        Go To Dashboard
+        Go to dashboard
       </Button>
     </ActionRow>
   </div>

--- a/src/containers/EnterpriseDashboardModal/messages.js
+++ b/src/containers/EnterpriseDashboardModal/messages.js
@@ -18,7 +18,7 @@ const messages = defineMessages({
   },
   enterpriseDialogConfirmButton: {
     id: 'leanerDashboard.enterpriseDialogConfirmButton',
-    defaultMessage: 'Go To Dashboard',
+    defaultMessage: 'Go to dashboard',
     description: 'Confirm button to go to the dashboard url',
   },
 });

--- a/src/containers/LearnerDashboardHeaderVariant/BrandLogo.jsx
+++ b/src/containers/LearnerDashboardHeaderVariant/BrandLogo.jsx
@@ -9,6 +9,7 @@ import messages from './messages';
 export const BrandLogo = () => {
   const { formatMessage } = useIntl();
   const dashboard = reduxHooks.useEnterpriseDashboardData();
+  console.log('BrandLogo', dashboard);
 
   return (
     <a href={dashboard?.url || '/'} className="mx-auto">

--- a/src/containers/LearnerDashboardHeaderVariant/BrandLogo.jsx
+++ b/src/containers/LearnerDashboardHeaderVariant/BrandLogo.jsx
@@ -9,7 +9,6 @@ import messages from './messages';
 export const BrandLogo = () => {
   const { formatMessage } = useIntl();
   const dashboard = reduxHooks.useEnterpriseDashboardData();
-  console.log('BrandLogo', dashboard);
 
   return (
     <a href={dashboard?.url || '/'} className="mx-auto">

--- a/src/data/redux/app/selectors/appSelectors.js
+++ b/src/data/redux/app/selectors/appSelectors.js
@@ -12,7 +12,7 @@ export const numCourses = createSelector(
 export const hasCourses = createSelector([module.numCourses], (num) => num > 0);
 export const hasAvailableDashboards = createSelector(
   [simpleSelectors.enterpriseDashboard],
-  (data) => data !== null,
+  (data) => data !== null && data.isLearnerPortalEnabled === true,
 );
 export const showSelectSessionModal = createSelector(
   [simpleSelectors.selectSessionModal],

--- a/src/data/redux/app/selectors/appSelectors.test.js
+++ b/src/data/redux/app/selectors/appSelectors.test.js
@@ -18,10 +18,11 @@ describe('basic app selectors', () => {
     });
   });
   describe('hasAvailableDashboards', () => {
-    it('returns true iff the enterpriseDashboard field is populated', () => {
+    it('returns true iff the enterpriseDashboard field is populated and learner portal is enabled', () => {
       const { preSelectors, cb } = appSelectors.hasAvailableDashboards;
       expect(preSelectors).toEqual([simpleSelectors.enterpriseDashboard]);
-      expect(cb({ data: 'test' })).toEqual(true);
+      expect(cb({ isLearnerPortalEnabled: true })).toEqual(true);
+      expect(cb({ isLearnerPortalEnabled: false })).toEqual(false);
       expect(cb(null)).toEqual(false);
     });
   });


### PR DESCRIPTION
# Description

The following modal appears for enterprise learners in the B2C learner dashboard. It intends to inform/communicate to enterprise learners that they have an enterprise-specific, branded dashboard page available to them:

<img width="1258" alt="image" src="https://user-images.githubusercontent.com/2828721/234695878-67c84c73-6e3e-4076-b806-f7f9d17b7146.png">

However, currently, the MFE assumes if you are an enterprise learner, you should be seeing the modal which is not true. The modal should only show for learners associated with an enterprise that has `enable_learner_portal=True`.

Related PR(s):
* https://github.com/openedx/edx-platform/pull/32142