### PR TITLE
fix: missing image

### DIFF
--- a/src/containers/CourseCard/components/CourseCardImage.jsx
+++ b/src/containers/CourseCard/components/CourseCardImage.jsx
@@ -24,7 +24,7 @@ export const CourseCardImage = ({ cardId, orientation }) => {
   const image = (
     <>
       <img
-        className="pgn__card-image-cap"
+        className="pgn__card-image-cap show"
         src={bannerImgSrc}
         alt={formatMessage(messages.bannerAlt)}
       />

--- a/src/containers/CourseCard/components/__snapshots__/CourseCardImage.test.jsx.snap
+++ b/src/containers/CourseCard/components/__snapshots__/CourseCardImage.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`CourseCardImage snapshot renders clickable link course Image 1`] = `
 >
   <img
     alt="Course thumbnail"
-    className="pgn__card-image-cap"
+    className="pgn__card-image-cap show"
     src="banner-img-src"
   />
   <span
@@ -45,7 +45,7 @@ exports[`CourseCardImage snapshot renders disabled link 1`] = `
 >
   <img
     alt="Course thumbnail"
-    className="pgn__card-image-cap"
+    className="pgn__card-image-cap show"
     src="banner-img-src"
   />
   <span


### PR DESCRIPTION
`Card.Img` expect `.show` from `paragon@20.28.4` onward, specially this pr https://github.com/openedx/paragon/pull/1994. Since course image is using custom css + paragon card img to include verify ribbon and disable/clickable function, this change was an edge case we didn't expect.