### PR TITLE
fix: stop user from unenroll after earned the certificate

### DIFF
--- a/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CourseCardMenu disable and stop rendering buttons snapshot when no dropdown items exist 1`] = `
+<Fragment>
+  <Dropdown>
+    <Dropdown.Toggle
+      alt="Course actions dropdown"
+      as="IconButton"
+      iconAs="Icon"
+      id="course-actions-dropdown-test-card-id"
+      src={[MockFunction icons.MoreVert]}
+      variant="primary"
+    />
+    <Dropdown.Menu>
+      <Dropdown.Item
+        data-testid="unenrollModalToggle"
+        disabled={false}
+        onClick={[MockFunction unenrollShow]}
+      >
+        Unenroll
+      </Dropdown.Item>
+      <Dropdown.Item
+        data-testid="emailSettingsModalToggle"
+        disabled={false}
+        onClick={[MockFunction emailSettingShow]}
+      >
+        Email settings
+      </Dropdown.Item>
+      <FacebookShareButton
+        className="pgn__dropdown-item dropdown-item"
+        onClick={[MockFunction facebookShareClick]}
+        resetButtonStyle={false}
+        title="I'm taking test-course-name online with facebook-social-brand.  Check it out!"
+        url="facebook-share-url"
+      >
+        Share to Facebook
+      </FacebookShareButton>
+      <TwitterShareButton
+        className="pgn__dropdown-item dropdown-item"
+        onClick={[MockFunction twitterShareClick]}
+        resetButtonStyle={false}
+        title="I'm taking test-course-name online with twitter-social-brand.  Check it out!"
+        url="twitter-share-url"
+      >
+        Share to Twitter
+      </TwitterShareButton>
+    </Dropdown.Menu>
+  </Dropdown>
+  <UnenrollConfirmModal
+    cardId="test-card-id"
+    closeModal={[MockFunction unenrollHide]}
+    show={false}
+  />
+  <EmailSettingsModal
+    cardId="test-card-id"
+    closeModal={[MockFunction emailSettingHide]}
+    show={false}
+  />
+</Fragment>
+`;
+
 exports[`CourseCardMenu enrolled, share enabled, email setting enable snapshot 1`] = `
 <Fragment>
   <Dropdown>
@@ -113,27 +172,6 @@ exports[`CourseCardMenu masquerading snapshot 1`] = `
   <EmailSettingsModal
     cardId="test-card-id"
     closeModal={[MockFunction emailSettingHide]}
-    show={false}
-  />
-</Fragment>
-`;
-
-exports[`CourseCardMenu not enrolled, share disabled, email setting disabled snapshot 1`] = `
-<Fragment>
-  <Dropdown>
-    <Dropdown.Toggle
-      alt="Course actions dropdown"
-      as="IconButton"
-      iconAs="Icon"
-      id="course-actions-dropdown-test-card-id"
-      src={[MockFunction icons.MoreVert]}
-      variant="primary"
-    />
-    <Dropdown.Menu />
-  </Dropdown>
-  <UnenrollConfirmModal
-    cardId="test-card-id"
-    closeModal={[MockFunction unenrollHide]}
     show={false}
   />
 </Fragment>

--- a/src/containers/CourseCard/components/CourseCardMenu/index.jsx
+++ b/src/containers/CourseCard/components/CourseCardMenu/index.jsx
@@ -25,6 +25,7 @@ export const CourseCardMenu = ({ cardId }) => {
   const { isEnrolled, isEmailEnabled } = reduxHooks.useCardEnrollmentData(cardId);
   const { twitter, facebook } = reduxHooks.useCardSocialSettingsData(cardId);
   const { isMasquerading } = reduxHooks.useMasqueradeData();
+  const { isEarned } = reduxHooks.useCardCertificateData(cardId);
   const handleTwitterShare = reduxHooks.useTrackCourseEvent(
     track.socialShare,
     cardId,
@@ -40,6 +41,13 @@ export const CourseCardMenu = ({ cardId }) => {
   const unenrollModal = useUnenrollData();
   const handleToggleDropdown = useHandleToggleDropdown(cardId);
 
+  const showUnenrollItem = isEnrolled && !isEarned;
+  const showDropdown = showUnenrollItem || isEmailEnabled || facebook.isEnabled || twitter.isEnabled;
+
+  if (!showDropdown) {
+    return null;
+  }
+
   return (
     <>
       <Dropdown onToggle={handleToggleDropdown}>
@@ -52,7 +60,7 @@ export const CourseCardMenu = ({ cardId }) => {
           alt={formatMessage(messages.dropdownAlt)}
         />
         <Dropdown.Menu>
-          {isEnrolled && (
+          {showUnenrollItem && (
             <Dropdown.Item
               disabled={isMasquerading}
               onClick={unenrollModal.show}

--- a/src/data/redux/app/selectors/courseCard.js
+++ b/src/data/redux/app/selectors/courseCard.js
@@ -24,6 +24,7 @@ export const courseCard = StrictDict({
         isDownloadable: certificate.isDownloadable,
         isEarnedButUnavailable: certificate.isEarned && !isAvailable,
         isRestricted: certificate.isRestricted,
+        isEarned: certificate.isEarned,
       };
     },
   ),


### PR DESCRIPTION
What changed?

- Add `isEarned` back to certificate selector. It was already there but we removed it.
- Do not render unenroll dropdown when the certificate already earned. (I prefer not rendering it just because staff can see the affect while masquerading).
- Make sure the dropdown doesn't show up when no option is available.

Ticket: https://2u-internal.atlassian.net/browse/AU-1232