### PR TITLE
fix: stop user from unenroll after earned the certificate

### DIFF
--- a/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,9 @@
 
 exports[`CourseCardMenu default snapshot 1`] = `
 <Fragment>
-  <Dropdown>
+  <Dropdown
+    onToggle={[MockFunction mockHandleToggleDropdown]}
+  >
     <Dropdown.Toggle
       alt="Course actions dropdown"
       as="IconButton"
@@ -61,7 +63,9 @@ exports[`CourseCardMenu default snapshot 1`] = `
 
 exports[`CourseCardMenu masquerading snapshot 1`] = `
 <Fragment>
-  <Dropdown>
+  <Dropdown
+    onToggle={[MockFunction mockHandleToggleDropdown]}
+  >
     <Dropdown.Toggle
       alt="Course actions dropdown"
       as="IconButton"

--- a/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
@@ -1,63 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CourseCardMenu disable and stop rendering buttons snapshot when no dropdown items exist 1`] = `
-<Fragment>
-  <Dropdown>
-    <Dropdown.Toggle
-      alt="Course actions dropdown"
-      as="IconButton"
-      iconAs="Icon"
-      id="course-actions-dropdown-test-card-id"
-      src={[MockFunction icons.MoreVert]}
-      variant="primary"
-    />
-    <Dropdown.Menu>
-      <Dropdown.Item
-        data-testid="unenrollModalToggle"
-        disabled={false}
-        onClick={[MockFunction unenrollShow]}
-      >
-        Unenroll
-      </Dropdown.Item>
-      <Dropdown.Item
-        data-testid="emailSettingsModalToggle"
-        disabled={false}
-        onClick={[MockFunction emailSettingShow]}
-      >
-        Email settings
-      </Dropdown.Item>
-      <FacebookShareButton
-        className="pgn__dropdown-item dropdown-item"
-        onClick={[MockFunction facebookShareClick]}
-        resetButtonStyle={false}
-        title="I'm taking test-course-name online with facebook-social-brand.  Check it out!"
-        url="facebook-share-url"
-      >
-        Share to Facebook
-      </FacebookShareButton>
-      <TwitterShareButton
-        className="pgn__dropdown-item dropdown-item"
-        onClick={[MockFunction twitterShareClick]}
-        resetButtonStyle={false}
-        title="I'm taking test-course-name online with twitter-social-brand.  Check it out!"
-        url="twitter-share-url"
-      >
-        Share to Twitter
-      </TwitterShareButton>
-    </Dropdown.Menu>
-  </Dropdown>
-  <UnenrollConfirmModal
-    cardId="test-card-id"
-    closeModal={[MockFunction unenrollHide]}
-    show={false}
-  />
-  <EmailSettingsModal
-    cardId="test-card-id"
-    closeModal={[MockFunction emailSettingHide]}
-    show={false}
-  />
-</Fragment>
-`;
+exports[`CourseCardMenu disable and stop rendering buttons snapshot when no dropdown items exist 1`] = `""`;
 
 exports[`CourseCardMenu enrolled, share enabled, email setting enable snapshot 1`] = `
 <Fragment>

--- a/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CourseCardMenu disable and stop rendering buttons snapshot when no dropdown items exist 1`] = `""`;
-
-exports[`CourseCardMenu enrolled, share enabled, email setting enable snapshot 1`] = `
+exports[`CourseCardMenu default snapshot 1`] = `
 <Fragment>
   <Dropdown>
     <Dropdown.Toggle
@@ -30,7 +28,7 @@ exports[`CourseCardMenu enrolled, share enabled, email setting enable snapshot 1
       </Dropdown.Item>
       <FacebookShareButton
         className="pgn__dropdown-item dropdown-item"
-        onClick={[MockFunction facebookShareClick]}
+        onClick={[MockFunction handleFacebookShare]}
         resetButtonStyle={false}
         title="I'm taking test-course-name online with facebook-social-brand.  Check it out!"
         url="facebook-share-url"
@@ -39,7 +37,7 @@ exports[`CourseCardMenu enrolled, share enabled, email setting enable snapshot 1
       </FacebookShareButton>
       <TwitterShareButton
         className="pgn__dropdown-item dropdown-item"
-        onClick={[MockFunction twitterShareClick]}
+        onClick={[MockFunction handleTwitterShare]}
         resetButtonStyle={false}
         title="I'm taking test-course-name online with twitter-social-brand.  Check it out!"
         url="twitter-share-url"
@@ -89,7 +87,7 @@ exports[`CourseCardMenu masquerading snapshot 1`] = `
       </Dropdown.Item>
       <FacebookShareButton
         className="pgn__dropdown-item dropdown-item"
-        onClick={[MockFunction facebookShareClick]}
+        onClick={[MockFunction handleFacebookShare]}
         resetButtonStyle={false}
         title="I'm taking test-course-name online with facebook-social-brand.  Check it out!"
         url="facebook-share-url"
@@ -98,7 +96,7 @@ exports[`CourseCardMenu masquerading snapshot 1`] = `
       </FacebookShareButton>
       <TwitterShareButton
         className="pgn__dropdown-item dropdown-item"
-        onClick={[MockFunction twitterShareClick]}
+        onClick={[MockFunction handleTwitterShare]}
         resetButtonStyle={false}
         title="I'm taking test-course-name online with twitter-social-brand.  Check it out!"
         url="twitter-share-url"
@@ -119,3 +117,5 @@ exports[`CourseCardMenu masquerading snapshot 1`] = `
   />
 </Fragment>
 `;
+
+exports[`CourseCardMenu renders null if showDropdown is false 1`] = `""`;

--- a/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardMenu/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CourseCardMenu disable and stop rendering buttons snapshot when no dropdown items exist 1`] = `
+<Fragment>
+  <Dropdown>
+    <Dropdown.Toggle
+      alt="Course actions dropdown"
+      as="IconButton"
+      iconAs="Icon"
+      id="course-actions-dropdown-test-card-id"
+      src={[MockFunction icons.MoreVert]}
+      variant="primary"
+    />
+    <Dropdown.Menu>
+      <Dropdown.Item
+        data-testid="unenrollModalToggle"
+        disabled={false}
+        onClick={[MockFunction unenrollShow]}
+      >
+        Unenroll
+      </Dropdown.Item>
+      <Dropdown.Item
+        data-testid="emailSettingsModalToggle"
+        disabled={false}
+        onClick={[MockFunction emailSettingShow]}
+      >
+        Email settings
+      </Dropdown.Item>
+      <FacebookShareButton
+        className="pgn__dropdown-item dropdown-item"
+        onClick={[MockFunction facebookShareClick]}
+        resetButtonStyle={false}
+        title="I'm taking test-course-name online with facebook-social-brand.  Check it out!"
+        url="facebook-share-url"
+      >
+        Share to Facebook
+      </FacebookShareButton>
+      <TwitterShareButton
+        className="pgn__dropdown-item dropdown-item"
+        onClick={[MockFunction twitterShareClick]}
+        resetButtonStyle={false}
+        title="I'm taking test-course-name online with twitter-social-brand.  Check it out!"
+        url="twitter-share-url"
+      >
+        Share to Twitter
+      </TwitterShareButton>
+    </Dropdown.Menu>
+  </Dropdown>
+  <UnenrollConfirmModal
+    cardId="test-card-id"
+    closeModal={[MockFunction unenrollHide]}
+    show={false}
+  />
+  <EmailSettingsModal
+    cardId="test-card-id"
+    closeModal={[MockFunction emailSettingHide]}
+    show={false}
+  />
+</Fragment>
+`;
+
 exports[`CourseCardMenu enrolled, share enabled, email setting enable snapshot 1`] = `
 <Fragment>
   <Dropdown>
@@ -113,27 +172,6 @@ exports[`CourseCardMenu masquerading snapshot 1`] = `
   <EmailSettingsModal
     cardId="test-card-id"
     closeModal={[MockFunction emailSettingHide]}
-    show={false}
-  />
-</Fragment>
-`;
-
-exports[`CourseCardMenu not enrolled, share disabled, email setting disabled snapshot 1`] = `
-<Fragment>
-  <Dropdown>
-    <Dropdown.Toggle
-      alt="Course actions dropdown"
-      as="IconButton"
-      iconAs="Icon"
-      id="course-actions-dropdown-test-card-id"
-      src={[MockFunction icons.MoreVert]}
-      variant="primary"
-    />
-    <Dropdown.Menu />
-  </Dropdown>
-  <UnenrollConfirmModal
-    cardId="test-card-id"
-    closeModal={[MockFunction unenrollHide]}
     show={false}
   />
 </Fragment>

--- a/src/containers/CourseCard/components/CourseCardMenu/hooks.js
+++ b/src/containers/CourseCard/components/CourseCardMenu/hooks.js
@@ -36,3 +36,36 @@ export const useHandleToggleDropdown = (cardId) => {
     if (isOpen) { trackCourseEvent(); }
   };
 };
+
+export const useCourseCardMenu = (cardId) => {
+  const { courseName } = reduxHooks.useCardCourseData(cardId);
+  const { isEnrolled, isEmailEnabled } = reduxHooks.useCardEnrollmentData(cardId);
+  const { twitter, facebook } = reduxHooks.useCardSocialSettingsData(cardId);
+  const { isMasquerading } = reduxHooks.useMasqueradeData();
+  const { isEarned } = reduxHooks.useCardCertificateData(cardId);
+  const handleTwitterShare = reduxHooks.useTrackCourseEvent(
+    track.socialShare,
+    cardId,
+    'twitter',
+  );
+  const handleFacebookShare = reduxHooks.useTrackCourseEvent(
+    track.socialShare,
+    cardId,
+    'facebook',
+  );
+
+  const showUnenrollItem = isEnrolled && !isEarned;
+  const showDropdown = showUnenrollItem || isEmailEnabled || facebook.isEnabled || twitter.isEnabled;
+
+  return {
+    courseName,
+    isMasquerading,
+    isEmailEnabled,
+    showUnenrollItem,
+    showDropdown,
+    facebook,
+    twitter,
+    handleTwitterShare,
+    handleFacebookShare,
+  };
+};

--- a/src/containers/CourseCard/components/CourseCardMenu/hooks.test.js
+++ b/src/containers/CourseCard/components/CourseCardMenu/hooks.test.js
@@ -7,6 +7,11 @@ import * as hooks from './hooks';
 jest.mock('hooks', () => ({
   reduxHooks: {
     useTrackCourseEvent: jest.fn(),
+    useCardCourseData: jest.fn(),
+    useCardEnrollmentData: jest.fn(),
+    useCardSocialSettingsData: jest.fn(),
+    useMasqueradeData: jest.fn(),
+    useCardCertificateData: jest.fn(),
   },
 }));
 
@@ -14,6 +19,18 @@ const trackCourseEvent = jest.fn();
 reduxHooks.useTrackCourseEvent.mockReturnValue(trackCourseEvent);
 const state = new MockUseState(hooks);
 
+const defaultSocialShare = {
+  facebook: {
+    isEnabled: true,
+    shareUrl: 'facebook-share-url',
+    socialBrand: 'facebook-social-brand',
+  },
+  twitter: {
+    isEnabled: true,
+    shareUrl: 'twitter-share-url',
+    socialBrand: 'twitter-social-brand',
+  },
+};
 const cardId = 'test-card-id';
 let out;
 
@@ -86,6 +103,118 @@ describe('CourseCardMenu hooks', () => {
         out(true);
         expect(trackCourseEvent).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('useCourseCardMenu', () => {
+    const mockUseCourseCardMenu = ({
+      courseName,
+      isEnrolled,
+      isEmailEnabled,
+      isMasquerading,
+      facebook,
+      twitter,
+      isEarned,
+    } = {}) => {
+      reduxHooks.useCardCourseData.mockReturnValueOnce({ courseName });
+      reduxHooks.useCardSocialSettingsData.mockReturnValueOnce({
+        facebook: {
+          ...defaultSocialShare.facebook,
+          ...facebook,
+        },
+        twitter: {
+          ...defaultSocialShare.twitter,
+          ...twitter,
+        },
+      });
+      reduxHooks.useCardEnrollmentData.mockReturnValueOnce({
+        isEnrolled,
+        isEmailEnabled,
+      });
+      reduxHooks.useMasqueradeData.mockReturnValueOnce({ isMasquerading });
+      reduxHooks.useCardCertificateData.mockReturnValueOnce({ isEarned });
+    };
+    afterEach(() => jest.resetAllMocks());
+    describe('showUnenrollItem', () => {
+      test('return true', () => {
+        mockUseCourseCardMenu({ isEnrolled: true, isEarned: false });
+        out = hooks.useCourseCardMenu(cardId);
+        expect(out.showUnenrollItem).toBeTruthy();
+      });
+
+      test('return false', () => {
+        mockUseCourseCardMenu({ isEnrolled: true, isEarned: true });
+        out = hooks.useCourseCardMenu(cardId);
+        expect(out.showUnenrollItem).toBeFalsy();
+
+        mockUseCourseCardMenu({ isEnrolled: false, isEarned: false });
+        out = hooks.useCourseCardMenu(cardId);
+        expect(out.showUnenrollItem).toBeFalsy();
+
+        mockUseCourseCardMenu({ isEnrolled: false, isEarned: true });
+        out = hooks.useCourseCardMenu(cardId);
+        expect(out.showUnenrollItem).toBeFalsy();
+      });
+    });
+
+    describe('showDropdown', () => {
+      test('return false iif everything is false', () => {
+        mockUseCourseCardMenu({
+          isEnrolled: false,
+          isEarned: false,
+          isEmailEnabled: false,
+          facebook: { isEnabled: false },
+          twitter: { isEnabled: false },
+        });
+        out = hooks.useCourseCardMenu(cardId);
+        expect(out.showDropdown).toBeFalsy();
+      });
+
+      test('return true iif at least one is true', () => {
+        mockUseCourseCardMenu({
+          isEnrolled: true,
+          isEarned: false,
+          isEmailEnabled: false,
+          facebook: { isEnabled: false },
+          twitter: { isEnabled: false },
+        });
+        out = hooks.useCourseCardMenu(cardId);
+        expect(out.showDropdown).toBeTruthy();
+      });
+    });
+
+    test('return correct values', () => {
+      const expected = {
+        courseName: 'abitrary-course-name',
+        isMasquerading: 'abitrary-masquerading-value',
+        isEmailEnabled: 'abitrary-email-enabled-value',
+        facebook: { isEnabled: 'abitrary-facebook-value' },
+        twitter: { isEnabled: 'abitrary-twitter-value' },
+      };
+      mockUseCourseCardMenu(expected);
+      out = hooks.useCourseCardMenu(cardId);
+      expect(out.courseName).toEqual(expected.courseName);
+      expect(out.isMasquerading).toEqual(expected.isMasquerading);
+      expect(out.isEmailEnabled).toEqual(expected.isEmailEnabled);
+      expect(out.facebook.isEnabled).toEqual(expected.facebook.isEnabled);
+      expect(out.twitter.isEnabled).toEqual(expected.twitter.isEnabled);
+    });
+
+    test('handleSocialShareClick', () => {
+      mockUseCourseCardMenu();
+
+      out = hooks.useCourseCardMenu(cardId);
+      expect(reduxHooks.useTrackCourseEvent).toHaveBeenCalledTimes(2);
+      expect(reduxHooks.useTrackCourseEvent).toHaveBeenCalledWith(
+        track.socialShare,
+        cardId,
+        'facebook',
+      );
+      expect(reduxHooks.useTrackCourseEvent).toHaveBeenCalledWith(
+        track.socialShare,
+        cardId,
+        'twitter',
+      );
     });
   });
 });

--- a/src/containers/CourseCard/components/CourseCardMenu/index.jsx
+++ b/src/containers/CourseCard/components/CourseCardMenu/index.jsx
@@ -6,14 +6,13 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { Dropdown, Icon, IconButton } from '@edx/paragon';
 import { MoreVert } from '@edx/paragon/icons';
 
-import track from 'tracking';
-import { reduxHooks } from 'hooks';
 import EmailSettingsModal from 'containers/EmailSettingsModal';
 import UnenrollConfirmModal from 'containers/UnenrollConfirmModal';
 import {
   useEmailSettings,
   useUnenrollData,
   useHandleToggleDropdown,
+  useCourseCardMenu,
 } from './hooks';
 
 import messages from './messages';
@@ -21,28 +20,21 @@ import messages from './messages';
 export const CourseCardMenu = ({ cardId }) => {
   const { formatMessage } = useIntl();
 
-  const { courseName } = reduxHooks.useCardCourseData(cardId);
-  const { isEnrolled, isEmailEnabled } = reduxHooks.useCardEnrollmentData(cardId);
-  const { twitter, facebook } = reduxHooks.useCardSocialSettingsData(cardId);
-  const { isMasquerading } = reduxHooks.useMasqueradeData();
-  const { isEarned } = reduxHooks.useCardCertificateData(cardId);
-  const handleTwitterShare = reduxHooks.useTrackCourseEvent(
-    track.socialShare,
-    cardId,
-    'twitter',
-  );
-  const handleFacebookShare = reduxHooks.useTrackCourseEvent(
-    track.socialShare,
-    cardId,
-    'facebook',
-  );
-
   const emailSettingsModal = useEmailSettings();
   const unenrollModal = useUnenrollData();
   const handleToggleDropdown = useHandleToggleDropdown(cardId);
 
-  const showUnenrollItem = isEnrolled && !isEarned;
-  const showDropdown = showUnenrollItem || isEmailEnabled || facebook.isEnabled || twitter.isEnabled;
+  const {
+    courseName,
+    isMasquerading,
+    isEmailEnabled,
+    showUnenrollItem,
+    showDropdown,
+    facebook,
+    twitter,
+    handleTwitterShare,
+    handleFacebookShare,
+  } = useCourseCardMenu(cardId);
 
   if (!showDropdown) {
     return null;

--- a/src/containers/CourseCard/components/CourseCardMenu/index.jsx
+++ b/src/containers/CourseCard/components/CourseCardMenu/index.jsx
@@ -25,6 +25,7 @@ export const CourseCardMenu = ({ cardId }) => {
   const { isEnrolled, isEmailEnabled } = reduxHooks.useCardEnrollmentData(cardId);
   const { twitter, facebook } = reduxHooks.useCardSocialSettingsData(cardId);
   const { isMasquerading } = reduxHooks.useMasqueradeData();
+  const { isEarned } = reduxHooks.useCardCertificateData(cardId);
   const handleTwitterShare = reduxHooks.useTrackCourseEvent(
     track.socialShare,
     cardId,
@@ -40,6 +41,13 @@ export const CourseCardMenu = ({ cardId }) => {
   const unenrollModal = useUnenrollData();
   const handleToggleDropdown = useHandleToggleDropdown(cardId);
 
+  const showUnenrollItem = isEnrolled && !isEarned;
+  const showDropdown = showUnenrollItem || isEmailEnabled || facebook.isEnabled || twitter.isEnabled;
+
+  if (!showDropdown) {
+    return null;
+  }
+
   return (
     <>
       <Dropdown onToggle={handleToggleDropdown}>
@@ -52,7 +60,7 @@ export const CourseCardMenu = ({ cardId }) => {
           alt={formatMessage(messages.dropdownAlt)}
         />
         <Dropdown.Menu>
-          {isEnrolled && (
+          {showUnenrollItem && (
             <Dropdown.Item
               disabled={isMasquerading}
               onClick={unenrollModal.show}

--- a/src/containers/CourseCard/components/CourseCardMenu/index.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardMenu/index.test.jsx
@@ -177,13 +177,21 @@ describe('CourseCardMenu', () => {
     });
     it('snapshot when no dropdown items exist', () => {
       wrapper = mockCourseCardMenu({
-        isEnrolled: true,
-        isEmailEnabled: true,
+        isEnrolled: false,
+        isEmailEnabled: false,
         isMasquerading: false,
         isEarned: false,
+        twitter: {
+          ...defaultSocialShare.twitter,
+          isEnabled: false,
+        },
+        facebook: {
+          ...defaultSocialShare.facebook,
+          isEnabled: false,
+        },
       });
       expect(wrapper).toMatchSnapshot();
-      expect(wrapper).toEqual({});
+      expect(wrapper.isEmptyRender()).toEqual(true);
     });
   });
   describe('masquerading', () => {

--- a/src/containers/CourseCard/components/CourseCardMenu/index.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardMenu/index.test.jsx
@@ -13,6 +13,7 @@ jest.mock('./hooks', () => ({
   useEmailSettings: jest.fn(),
   useUnenrollData: jest.fn(),
   useCourseCardMenu: jest.fn(),
+  useHandleToggleDropdown: () => jest.fn().mockName('mockHandleToggleDropdown'),
 }));
 
 const props = {

--- a/src/data/redux/app/selectors/courseCard.js
+++ b/src/data/redux/app/selectors/courseCard.js
@@ -15,17 +15,14 @@ export const loadDateVal = (date) => (date ? new Date(date) : null);
 export const courseCard = StrictDict({
   certificate: mkCardSelector(
     cardSimpleSelectors.certificate,
-    (certificate) => {
-      const availableDate = new Date(certificate.availableDate);
-      const isAvailable = availableDate <= new Date();
-      return {
-        availableDate,
-        certPreviewUrl: baseAppUrl(certificate.certPreviewUrl),
-        isDownloadable: certificate.isDownloadable,
-        isEarnedButUnavailable: certificate.isEarned && !isAvailable,
-        isRestricted: certificate.isRestricted,
-      };
-    },
+    (certificate) => (certificate === null ? {} : ({
+      availableDate: new Date(certificate.availableDate),
+      certPreviewUrl: baseAppUrl(certificate.certPreviewUrl),
+      isDownloadable: certificate.isDownloadable,
+      isEarnedButUnavailable: certificate.isEarned && new Date(certificate.availableDate) > new Date(),
+      isRestricted: certificate.isRestricted,
+      isEarned: certificate.isEarned,
+    })),
   ),
   course: mkCardSelector(
     cardSimpleSelectors.course,

--- a/src/data/redux/app/selectors/courseCard.test.js
+++ b/src/data/redux/app/selectors/courseCard.test.js
@@ -79,6 +79,9 @@ describe('courseCard selectors module', () => {
       it('returns a card selector based on certificate cardSimpleSelector', () => {
         expect(simpleSelector).toEqual(cardSimpleSelectors.certificate);
       });
+      it('returns {} object if null certificate received', () => {
+        expect(selector(null)).toEqual({});
+      });
       it('passes availableDate, converted to a date', () => {
         expect(selected.availableDate).toMatchObject(new Date(testData.availableDate));
       });
@@ -161,6 +164,9 @@ describe('courseCard selectors module', () => {
       });
       it('returns a card selector based on courseRun cardSimpleSelector', () => {
         expect(simpleSelector).toEqual(cardSimpleSelectors.courseRun);
+      });
+      it('returns {} object if null courseRun received', () => {
+        expect(selector(null)).toEqual({});
       });
       it('passes [endDate, startDate], converted to dates', () => {
         expect(selected.endDate).toEqual(new Date(testData.endDate));


### PR DESCRIPTION
An update from previous pr https://github.com/openedx/frontend-app-learner-dashboard/pull/155

Previous pr break because `certificate = null` from the server.