### PR TITLE
fix: adjusted footer widget to show placeholder for no recommendations

### DIFF
--- a/src/widgets/ProductRecommendations/index.jsx
+++ b/src/widgets/ProductRecommendations/index.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { reduxHooks } from 'hooks';
 import './index.scss';
 import { useWindowSize, breakpoints } from '@edx/paragon';
-import { useProductRecommendationsData } from './hooks';
+import NoCoursesView from 'containers/CourseList/NoCoursesView';
 import LoadingView from './components/LoadingView';
 import LoadedView from './components/LoadedView';
-import NoCoursesView from '../../containers/CourseList/NoCoursesView';
+import { useProductRecommendationsData } from './hooks';
 
 const ProductRecommendations = () => {
   const checkEmptyResponse = (obj) => {

--- a/src/widgets/ProductRecommendations/index.jsx
+++ b/src/widgets/ProductRecommendations/index.jsx
@@ -1,28 +1,41 @@
 import React from 'react';
+import { reduxHooks } from 'hooks';
 import './index.scss';
 import { useWindowSize, breakpoints } from '@edx/paragon';
 import { useProductRecommendationsData } from './hooks';
 import LoadingView from './components/LoadingView';
 import LoadedView from './components/LoadedView';
+import NoCoursesView from '../../containers/CourseList/NoCoursesView';
 
 const ProductRecommendations = () => {
+  const checkEmptyResponse = (obj) => {
+    const values = Object.values(obj);
+    const result = values.filter((item) => item.length === 0);
+    return result.length === values.length;
+  };
+
   const { productRecommendations, isLoading, isLoaded } = useProductRecommendationsData();
   const { width } = useWindowSize();
   const isMobile = width < breakpoints.small.minWidth;
+  const hasCourses = reduxHooks.useHasCourses();
+  const shouldShowPlaceholder = checkEmptyResponse(productRecommendations);
 
   if (isLoading && !isMobile) {
     return <LoadingView />;
   }
 
-  if (isLoaded && !isMobile) {
+  if (isLoaded && !isMobile && !shouldShowPlaceholder) {
     return (
       <LoadedView
         openCourses={productRecommendations.amplitudeCourses}
-        crossProductCourses={productRecommendations.crossProductCourses}
+        crossProductCourses={productRecommendations.crossProductCourses || []}
       />
     );
   }
 
+  if (isLoaded && hasCourses && !isMobile && shouldShowPlaceholder) {
+    return <NoCoursesView />;
+  }
   return null;
 };
 

--- a/src/widgets/ProductRecommendations/testData.js
+++ b/src/widgets/ProductRecommendations/testData.js
@@ -22,10 +22,21 @@ export const getCoursesWithType = (courseTypes) => {
   return courses;
 };
 
+export const mockFooterRecommendationsHook = {
+  showAndLoad: { shouldShowFooter: true, shouldLoadFooter: true },
+  showDontLoad: { shouldShowFooter: true, shouldLoadFooter: false },
+  loadDontShow: { shouldShowFooter: false, shouldLoadFooter: true },
+  dontShowOrLoad: { shouldShowFooter: false, shouldLoadFooter: false },
+};
+
 export const mockCrossProductCourses = getCoursesWithType(['executive-education-2u', 'bootcamp-2u']);
 export const mockOpenCourses = getCoursesWithType(['verified-audit', 'audit', 'verified', 'course']);
 
-export const mockResponse = {
+export const mockCrossProductResponse = {
   crossProductCourses: mockCrossProductCourses,
+  amplitudeCourses: mockOpenCourses,
+};
+
+export const mockAmplitudeResponse = {
   amplitudeCourses: mockOpenCourses,
 };


### PR DESCRIPTION
### Description

NB: Widget still hardcoded to not show

- Adjusted the product recommendations widget to display the `NoCoursesView` component if no recommendations is returned from our `product_recommendations` endpoints
- This specific case is if we are dealing with a user who is enrolled in a UT Austin Masters program, in which case, they should not see recommendations
- The placeholder will be displayed in place of our component if the user is enrolled in a course, otherwise, our component will just be hidden since the `NoCoursesView` component is shown by default when the user is not enrolled in anything.

### Jira Ticket
[PTECH-3276](https://jira.2u.com/browse/PTECH-3276)

### Screenshots
**View if the user is enrolled in a course, but received no recommendations**
<img width="1728" alt="Screenshot 2023-06-28 at 16 10 38" src="https://github.com/openedx/frontend-app-learner-dashboard/assets/110463597/bee46a64-4f6d-406d-ac3d-ea71c583341d">

**View if the user is NOT enrolled in a course and received no recommendations**
<img width="1728" alt="Screenshot 2023-06-28 at 16 11 18" src="https://github.com/openedx/frontend-app-learner-dashboard/assets/110463597/f64c5e23-9704-4c09-a801-2e328512bee3">

