### PR TITLE
fix: removed info Optimizely logs

### DIFF
--- a/src/widgets/ProductRecommendations/optimizely.js
+++ b/src/widgets/ProductRecommendations/optimizely.js
@@ -1,9 +1,15 @@
-import { createInstance } from '@optimizely/react-sdk';
+import { createInstance, setLogLevel } from '@optimizely/react-sdk';
 
 const OPTIMIZELY_SDK_KEY = process.env.OPTIMIZELY_FULL_STACK_SDK_KEY;
 
-const optimizelyClient = createInstance({
-  sdkKey: OPTIMIZELY_SDK_KEY,
-});
+const configureClient = () => {
+  setLogLevel('error');
+
+  return createInstance({
+    sdkKey: OPTIMIZELY_SDK_KEY,
+  });
+};
+
+const optimizelyClient = configureClient();
 
 export default optimizelyClient;

--- a/src/widgets/ProductRecommendations/optimizely.test.js
+++ b/src/widgets/ProductRecommendations/optimizely.test.js
@@ -1,13 +1,15 @@
-import { createInstance } from '@optimizely/react-sdk';
+import { createInstance, setLogLevel } from '@optimizely/react-sdk';
 import optimizelyClient from './optimizely';
 
 jest.mock('@optimizely/react-sdk', () => ({
   createInstance: jest.fn(() => 'mockedClient'),
+  setLogLevel: jest.fn(),
 }));
 
 describe('optimizelyClient', () => {
-  it('should create an Optimizely client instance with the correct SDK key', () => {
+  it('should configure an Optimizely client instance with the correct SDK key', () => {
     expect(optimizelyClient).toBeDefined();
+    expect(setLogLevel).toHaveBeenCalledWith('error');
     expect(createInstance).toHaveBeenCalledWith({ sdkKey: 'SDK Key' });
   });
 });


### PR DESCRIPTION
### Description

- Adjusted the creation of the Optimizely client to set the log level to `error` before creating the client, so only logs with a level of `error` are output to the console.

This is because currently, all Optimizely logs are being output to the console, and 1 log in particular includes the currently logged in user's ID, which poses as a potential security issue

### JIRA Ticket

[PTECH-3307](https://jira.2u.com/browse/PTECH-3307)