### PR TITLE
fix(deps): replace edx.org brand dependency with openedx brand (#183)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "^1.1.0",
         "@edx/frontend-component-footer": "^12.2.1",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
@@ -1945,10 +1945,10 @@
       }
     },
     "node_modules/@edx/brand": {
-      "name": "@edx/brand-edx.org",
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.2.tgz",
-      "integrity": "sha512-pBhUuegRg+2k63LWe3vyQDCdAiWTduaJ3hpHWqLZC3wYYyAyour6VGUbS1m9kg3+BmLz6AZR9P10BXT0iso6XQ=="
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.2.tgz",
+      "integrity": "sha512-mBvxR7aB9290j9+h3d/9G8VkG1b8ecLSmlxc0vskfm7DL/fKUzFmHAj3PI7Z4kkwCQOL4QT5mJHJKC0ZFf7qvQ=="
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
+    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "^1.1.0",
     "@edx/frontend-component-footer": "^12.2.1",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",


### PR DESCRIPTION
@edx/brand-edx.org package is not open source. @edx/brand-openedx is what is used by other MFEs by default.

Similar PRs:
- [Gradebook](https://github.com/openedx/frontend-app-gradebook/pull/327)
- [ORA grading](https://github.com/openedx/frontend-app-ora-grading/pull/200)