### PR TITLE
feat: Update header user dropdown back to Order History

### DIFF
--- a/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
+++ b/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
@@ -81,7 +81,7 @@ export const CollapseMenuBody = ({ isOpen }) => {
                 variant="inverse-primary"
                 href={getConfig().ORDER_HISTORY_URL}
               >
-                {formatMessage(messages.ordersAndSubscriptions)}
+                {formatMessage(messages.orderHistory)}
               </Button>
             )}
             <Button

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/AuthenticatedUserDropdown.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/AuthenticatedUserDropdown.jsx
@@ -55,7 +55,7 @@ export const AuthenticatedUserDropdown = () => {
           </Dropdown.Item>
           {getConfig().ORDER_HISTORY_URL && (
             <Dropdown.Item href={getConfig().ORDER_HISTORY_URL}>
-              {formatMessage(messages.ordersAndSubscriptions)}
+              {formatMessage(messages.orderHistory)}
             </Dropdown.Item>
           )}
           <Dropdown.Divider />

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
@@ -55,7 +55,7 @@ exports[`AuthenticatedUserDropdown snapshots with enterprise dashboard 1`] = `
     <Dropdown.Item
       href="http://order-history-url.test"
     >
-      Orders & Subscriptions
+      Order History
     </Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item
@@ -122,7 +122,7 @@ exports[`AuthenticatedUserDropdown snapshots without enterprise dashboard and ex
     <Dropdown.Item
       href="http://order-history-url.test"
     >
-      Orders & Subscriptions
+      Order History
     </Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item

--- a/src/containers/LearnerDashboardHeader/messages.js
+++ b/src/containers/LearnerDashboardHeader/messages.js
@@ -26,10 +26,10 @@ const messages = defineMessages({
     defaultMessage: 'Account',
     description: 'The text for the user menu Account navigation link.',
   },
-  ordersAndSubscriptions: {
-    id: 'learnerVariantDashboard.menu.ordersAndSubscriptions.label',
-    defaultMessage: 'Orders & Subscriptions',
-    description: 'The text for the user menu Orders & Subscriptions navigation link.',
+  orderHistory: {
+    id: 'learnerVariantDashboard.menu.orderHistory.label',
+    defaultMessage: 'Order History',
+    description: 'The text for the user menu Order History navigation link.',
   },
   signOut: {
     id: 'learnerVariantDashboard.menu.signOut.label',


### PR DESCRIPTION
[REV-3693](https://2u-internal.atlassian.net/browse/REV-3693).

Modifying the header dropdown back to `Order History` from `Orders & Subscriptions`.
This PR manually reverts https://github.com/openedx/frontend-app-learner-dashboard/pull/164