### PR TITLE
fix: default context for painted door experiment

### DIFF
--- a/src/widgets/RecommendationsPaintedDoorBtn/PaintedDoorExperimentContext.jsx
+++ b/src/widgets/RecommendationsPaintedDoorBtn/PaintedDoorExperimentContext.jsx
@@ -68,7 +68,13 @@ export const useIsEnterpriseUser = () => {
   return enterpriseUser;
 };
 
-export const PaintedDoorExperimentContext = React.createContext();
+export const PaintedDoorExperimentContext = React.createContext({
+  experimentVariation: null,
+  isPaintedDoorNavbarBtnVariation: null,
+  isPaintedDoorWidgetBtnVariation: null,
+  isPaintedDoorControlVariation: null,
+  experimentLoading: null,
+});
 
 export const PaintedDoorExperimentProvider = ({ children }) => {
   const [experimentData, setExperimentData] = module.state.experimentData({


### PR DESCRIPTION
There are multiple places where properties of the object provided by `usePaintedDoorExperimentContext()` are assumed to exist. This provides default (null) values for those properties when creating the context.

### This PR is proposing a solution to https://github.com/openedx/frontend-app-learner-dashboard/issues/210 that would make it so https://github.com/openedx/frontend-app-learner-dashboard/pull/214 isn't needed.