### PR TITLE
fix: scrollbars

### DIFF
--- a/plugins/PluginSlot.jsx
+++ b/plugins/PluginSlot.jsx
@@ -27,7 +27,7 @@ const PluginSlot = forwardRef(({
         keepDefault: true,
         plugins: [
           {
-            url: 'https://profile-velvetslice.sandbox.edx.org/u/verified/plugin',
+            url: `https://profile-velvetslice.sandbox.edx.org/u/${authenticatedUser.username}/plugin`,
             type: IFRAME_PLUGIN,
           },
           {

--- a/src/containers/CourseList/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseList/__snapshots__/index.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`CourseList collapsed with multiple courses and pages snapshot 1`] = `
       className="course-list-title"
     >
       My Courses
+       POC branch
     </h2>
     <div
       className="course-filter-controls-container"
@@ -60,6 +61,7 @@ exports[`CourseList no courses snapshot 1`] = `
       className="course-list-title"
     >
       My Courses
+       POC branch
     </h2>
     <div
       className="course-filter-controls-container"
@@ -84,6 +86,7 @@ exports[`CourseList no filters snapshot 1`] = `
       className="course-list-title"
     >
       My Courses
+       POC branch
     </h2>
     <div
       className="course-filter-controls-container"
@@ -108,6 +111,7 @@ exports[`CourseList with filters snapshot 1`] = `
       className="course-list-title"
     >
       My Courses
+       POC branch
     </h2>
     <div
       className="course-filter-controls-container"
@@ -141,6 +145,7 @@ exports[`CourseList with multiple courses and pages snapshot 1`] = `
       className="course-list-title"
     >
       My Courses
+       POC branch
     </h2>
     <div
       className="course-filter-controls-container"

--- a/src/containers/Dashboard/index.jsx
+++ b/src/containers/Dashboard/index.jsx
@@ -24,7 +24,7 @@ export const Dashboard = () => {
 
   return (
     <div id="dashboard-container" className="d-flex flex-column p-2 pt-0">
-      <h1 className="sr-only">{pageTitle} POC branch</h1>
+      <h1 className="sr-only">{pageTitle}</h1>
       {!initIsPending && (
         <>
           {hasAvailableDashboards && <EnterpriseDashboardModal />}

--- a/src/containers/WidgetContainers/NoCoursesSidebar/__snapshots__/index.test.jsx.snap
+++ b/src/containers/WidgetContainers/NoCoursesSidebar/__snapshots__/index.test.jsx.snap
@@ -18,7 +18,8 @@ exports[`WidgetSidebar snapshots default 1`] = `
       }
       style={
         Object {
-          "height": 400,
+          "height": 800,
+          "width": "100%",
         }
       }
     >


### PR DESCRIPTION
Combined with [work that got pushed directly to the branch](https://github.com/openedx/frontend-app-learner-dashboard/commit/c3dcf8e0321e822d26a9cafa40a726b036687475) will remove the flickering scrollbars during resize and enable the plugin to take up all available horizontal space (`width: 100%;`)