### PR TITLE
fix: get brand logo file path from env (#205)

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -16,6 +16,7 @@ const configuration = {
   SUPPORT_URL: process.env.SUPPORT_URL || null,
   ENABLE_NOTICES: process.env.ENABLE_NOTICES || null,
   CAREER_LINK_URL: process.env.CAREER_LINK_URL || null,
+  LOGO_URL: process.env.LOGO_URL,
 };
 
 const features = {};

--- a/src/containers/LearnerDashboardHeader/BrandLogo.jsx
+++ b/src/containers/LearnerDashboardHeader/BrandLogo.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { reduxHooks } from 'hooks';
+import { configuration } from '../../config';
 
 import messages from './messages';
 
@@ -14,7 +15,7 @@ export const BrandLogo = () => {
     <a href={dashboard?.url || '/'} className="mx-auto">
       <img
         className="logo py-3"
-        src="https://edx-cdn.org/v3/prod/logo.svg"
+        src={configuration.LOGO_URL}
         alt={formatMessage(messages.logoAltText)}
       />
     </a>

--- a/src/containers/LearnerDashboardHeader/__snapshots__/BrandLogo.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/__snapshots__/BrandLogo.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`BrandLogo dashboard defined 1`] = `
   <img
     alt="edX, Inc. Dashboard"
     className="logo py-3"
-    src="https://edx-cdn.org/v3/prod/logo.svg"
+    src="https://edx-cdn.org/v3/default/logo.svg"
   />
 </a>
 `;
@@ -21,7 +21,7 @@ exports[`BrandLogo dashboard undefined 1`] = `
   <img
     alt="edX, Inc. Dashboard"
     className="logo py-3"
-    src="https://edx-cdn.org/v3/prod/logo.svg"
+    src="https://edx-cdn.org/v3/default/logo.svg"
   />
 </a>
 `;


### PR DESCRIPTION
This PR makes changes so that the `LOGO_URL` can be used from the config in the `Quince` branch. These changes have already been made and merged in the `master` branch. 

The PR for the master branch is linked here: https://github.com/openedx/frontend-app-learner-dashboard/pull/205 & https://github.com/openedx/frontend-app-learner-dashboard/pull/238

Additional context: https://github.com/openedx/frontend-app-learner-dashboard/issues/178