### PR TITLE
chore: add Aperture team OpsGenie email address as a recipient when CI fails for Learner Dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         username: ${{ secrets.EDX_SMTP_USERNAME }}
         password: ${{ secrets.EDX_SMTP_PASSWORD }}
         subject: CI workflow failed in ${{github.repository}}
-        to: masters-grades@edx.org
+        to: masters-grades@edx.org,aperture@2u-internal.opsgenie.net
         from: github-actions <github-actions@edx.org>
         body: CI workflow in ${{github.repository}} failed!
           For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id


### PR DESCRIPTION
[APER-3072]

As this service transitions to Aperture for maintainership, we want to ensure that our team receives emails when CI fails in this project.