### PR TITLE
fix: URLs get the current value of LMS_BASE_URL from getConfig()

### DIFF
--- a/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
+++ b/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
@@ -29,7 +29,7 @@ export const CollapseMenuBody = ({ isOpen }) => {
         <Button as="a" href="/" variant="inverse-primary">
           {formatMessage(messages.course)}
         </Button>
-        <Button as="a" href={urls.programsUrl} variant="inverse-primary">
+        <Button as="a" href={urls.programsUrl()} variant="inverse-primary">
           {formatMessage(messages.program)}
         </Button>
         <Button

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
@@ -37,7 +37,7 @@ export const ExpandedHeader = () => {
         </Button>
         <Button
           as="a"
-          href={urls.programsUrl}
+          href={urls.programsUrl()}
           variant="inverse-primary"
           className="p-4"
         >

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/index.test.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/index.test.jsx
@@ -5,7 +5,7 @@ import ExpandedHeader from '.';
 import { useIsCollapsed } from '../hooks';
 
 jest.mock('data/services/lms/urls', () => ({
-  programsUrl: 'programsUrl',
+  programsUrl: () => 'programsUrl',
   baseAppUrl: url => (`http://localhost:18000${url}`),
 }));
 

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -34,16 +34,16 @@ export const deleteEntitlementEnrollment = ({ uuid, isRefundable }) => client()
   );
 
 export const updateEmailSettings = ({ courseId, enable }) => post(
-  urls.updateEmailSettings,
+  urls.updateEmailSettings(),
   { [apiKeys.courseId]: courseId, ...(enable && enableEmailsAction) },
 );
 
 export const unenrollFromCourse = ({ courseId }) => post(
-  urls.courseUnenroll,
+  urls.courseUnenroll(),
   { [apiKeys.courseId]: courseId, ...unenrollmentAction },
 );
 
-export const logEvent = ({ eventName, data, courseId }) => post(urls.event, {
+export const logEvent = ({ eventName, data, courseId }) => post(urls.event(), {
   courserun_key: courseId,
   event_type: eventName,
   page: window.location.href,

--- a/src/data/services/lms/api.test.js
+++ b/src/data/services/lms/api.test.js
@@ -77,7 +77,7 @@ describe('lms api methods', () => {
         expect(
           api.updateEmailSettings({ courseId, enable: false }),
         ).toEqual(
-          utils.post(urls.updateEmailSettings, { [apiKeys.courseId]: courseId }),
+          utils.post(urls.updateEmailSettings(), { [apiKeys.courseId]: courseId }),
         );
       });
     });
@@ -87,7 +87,7 @@ describe('lms api methods', () => {
           api.updateEmailSettings({ courseId, enable: true }),
         ).toEqual(
           utils.post(
-            urls.updateEmailSettings,
+            urls.updateEmailSettings(),
             { [apiKeys.courseId]: courseId, ...enableEmailsAction },
           ),
         );
@@ -100,7 +100,7 @@ describe('lms api methods', () => {
         api.unenrollFromCourse({ courseId }),
       ).toEqual(
         utils.post(
-          urls.courseUnenroll,
+          urls.courseUnenroll(),
           { [apiKeys.courseId]: courseId, ...unenrollmentAction },
         ),
       );
@@ -116,7 +116,7 @@ describe('lms api methods', () => {
         expect(
           api.logEvent({ courseId, eventName, data }),
         ).toEqual(
-          utils.post(urls.event, {
+          utils.post(urls.event(), {
             courserun_key: courseId,
             event_type: eventName,
             page: href,

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -10,9 +10,9 @@ export const getApiUrl = () => (`${getConfig().LMS_BASE_URL}/api`);
 
 const getInitApiUrl = () => (`${getApiUrl()}/learner_home/init`);
 
-const event = `${getBaseUrl()}/event`;
-const courseUnenroll = `${getBaseUrl()}/change_enrollment`;
-const updateEmailSettings = `${getApiUrl()}/change_email_settings`;
+const event = () => `${getBaseUrl()}/event`;
+const courseUnenroll = () => `${getBaseUrl()}/change_enrollment`;
+const updateEmailSettings = () => `${getApiUrl()}/change_email_settings`;
 const entitlementEnrollment = (uuid) => `${getApiUrl()}/entitlements/v1/entitlements/${uuid}/enrollments`;
 
 // if url is null or absolute, return it as is
@@ -22,7 +22,7 @@ export const baseAppUrl = (url) => updateUrl(getBaseUrl(), url);
 export const learningMfeUrl = (url) => updateUrl(getConfig().LEARNING_BASE_URL, url);
 
 // static view url
-const programsUrl = baseAppUrl('/dashboard/programs');
+const programsUrl = () => baseAppUrl('/dashboard/programs');
 
 export const creditPurchaseUrl = (courseId) => `${getEcommerceUrl()}/credit/checkout/${courseId}/`;
 export const creditRequestUrl = (providerId) => `${getApiUrl()}/credit/v1/providers/${providerId}/request/`;


### PR DESCRIPTION
### Description
This PR is a backport for https://github.com/openedx/frontend-app-learner-dashboard/pull/273 so unenrollments work in the learner dashboard.

Resolves https://github.com/openedx/wg-build-test-release/issues/336