### PR TITLE
fix: #287 translation strigs are not exported

### DIFF
--- a/src/components/ZendeskFab/messages.js
+++ b/src/components/ZendeskFab/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   supportTitle: {
     id: 'zendesk.supportTitle',
     description: 'Title for the support button',

--- a/src/containers/CourseCard/components/CourseCardActions/messages.js
+++ b/src/containers/CourseCard/components/CourseCardActions/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   upgrade: {
     id: 'learner-dash.courseCard.actions.upgrade',
     description: 'Course card upgrade button text',

--- a/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/messages.js
+++ b/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   error: {
     id: 'learner-dash.courseCard.banners.credit.error',
     description: '',

--- a/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/views/messages.js
+++ b/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/views/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   approved: {
     id: 'learner-dash.courseCard.banners.credit.approved',
     description: '',

--- a/src/containers/CourseCard/components/CourseCardBanners/RelatedProgramsBanner/messages.js
+++ b/src/containers/CourseCard/components/CourseCardBanners/RelatedProgramsBanner/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   relatedPrograms: {
     id: 'learner-dash.courseCard.banners.relatedPrograms',
     description: 'title for related programs banner',

--- a/src/containers/CourseCard/components/CourseCardBanners/messages.js
+++ b/src/containers/CourseCard/components/CourseCardBanners/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   auditAccessExpired: {
     id: 'learner-dash.courseCard.banners.auditAccessExpired',
     description: 'Audit access expiration banner message',

--- a/src/containers/CourseCard/components/CourseCardDetails/messages.js
+++ b/src/containers/CourseCard/components/CourseCardDetails/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   accessExpired: {
     id: 'learner-dash.courseCard.CourseCardDetails.accessExpired',
     description: 'Course access expiration date message on course card for expired access.',

--- a/src/containers/CourseCard/components/CourseCardMenu/SocialShareMenu.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardMenu/SocialShareMenu.test.jsx
@@ -21,6 +21,7 @@ jest.mock('tracking', () => ({
 }));
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
   useIntl: jest.fn().mockReturnValue({
     formatMessage: jest.requireActual('@edx/react-unit-test-utils').formatMessage,
   }),

--- a/src/containers/CourseCard/components/CourseCardMenu/index.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardMenu/index.test.jsx
@@ -12,6 +12,7 @@ import * as hooks from './hooks';
 import CourseCardMenu, { testIds } from '.';
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
   useIntl: jest.fn().mockReturnValue({
     formatMessage: jest.requireActual('@edx/react-unit-test-utils').formatMessage,
   }),

--- a/src/containers/CourseCard/components/CourseCardMenu/messages.js
+++ b/src/containers/CourseCard/components/CourseCardMenu/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   unenroll: {
     id: 'learner-dash.courseCardMenu.unenroll',
     description: 'Course unenroll menu button',

--- a/src/containers/CourseCard/messages.js
+++ b/src/containers/CourseCard/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   bannerAlt: {
     id: 'learner-dash.courseCard.bannerAlt',
     description: 'Course card banner alt-text',

--- a/src/containers/EmailSettingsModal/messages.js
+++ b/src/containers/EmailSettingsModal/messages.js
@@ -1,7 +1,7 @@
 /* eslint-disable quotes */
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   header: {
     id: 'learner-dash.emailSettings.header',
     description: 'Header for email settings modal',

--- a/src/containers/RelatedProgramsModal/messages.js
+++ b/src/containers/RelatedProgramsModal/messages.js
@@ -1,7 +1,7 @@
 /* eslint-disable quotes */
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   header: {
     id: 'learner-dash.relatedPrograms.header',
     description: 'Header for related settings modal',

--- a/src/containers/SelectSessionModal/messages.js
+++ b/src/containers/SelectSessionModal/messages.js
@@ -1,7 +1,7 @@
 /* eslint-disable quotes */
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   changeOrLeaveHeader: {
     id: 'learner-dash.selectSession.changeOrLeaveHeader',
     description: 'Header for session that allow leave option',

--- a/src/containers/UnenrollConfirmModal/components/messages.js
+++ b/src/containers/UnenrollConfirmModal/components/messages.js
@@ -1,7 +1,7 @@
 /* eslint-disable quotes */
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   confirmHeader: {
     id: 'learner-dash.unenrollConfirm.confirm.header',
     description: 'Header for confirm unenroll modal',

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,6 +1,6 @@
-import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
-export const messages = StrictDict({
+const messages = defineMessages({
   loadingSR: {
     id: 'learner-dash.loadingSR',
     description: 'Page loading screen-reader text',


### PR DESCRIPTION
This is a fix of #287 . 

It just replace the function used to define messages as explined in the issue, and modifies `*.test` files when/if needed