### PR TITLE
feat!: Removes rendering of the RecommendationsPanel by default in Open edX

### DIFF
--- a/src/containers/WidgetContainers/LoadedSidebar/__snapshots__/index.test.jsx.snap
+++ b/src/containers/WidgetContainers/LoadedSidebar/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,9 @@ exports[`WidgetSidebar snapshots default 1`] = `
   <div
     className="d-flex flex-column"
   >
-    <RecommendationsPanel />
+    <PluginSlot
+      id="widget_sidebar_plugin_slot"
+    />
   </div>
 </div>
 `;

--- a/src/containers/WidgetContainers/LoadedSidebar/index.jsx
+++ b/src/containers/WidgetContainers/LoadedSidebar/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
-import RecommendationsPanel from 'widgets/RecommendationsPanel';
 import hooks from 'widgets/ProductRecommendations/hooks';
 
 export const WidgetSidebar = ({ setSidebarShowing }) => {
@@ -13,7 +13,7 @@ export const WidgetSidebar = ({ setSidebarShowing }) => {
     return (
       <div className="widget-sidebar">
         <div className="d-flex flex-column">
-          <RecommendationsPanel />
+          <PluginSlot id="widget_sidebar_plugin_slot" />
         </div>
       </div>
     );

--- a/src/containers/WidgetContainers/LoadedSidebar/index.test.jsx
+++ b/src/containers/WidgetContainers/LoadedSidebar/index.test.jsx
@@ -8,6 +8,9 @@ jest.mock('widgets/LookingForChallengeWidget', () => 'LookingForChallengeWidget'
 jest.mock('widgets/ProductRecommendations/hooks', () => ({
   useShowRecommendationsFooter: jest.fn(),
 }));
+jest.mock('@openedx/frontend-plugin-framework', () => ({
+  PluginSlot: 'PluginSlot',
+}));
 
 describe('WidgetSidebar', () => {
   beforeEach(() => jest.resetAllMocks());

--- a/src/containers/WidgetContainers/NoCoursesSidebar/__snapshots__/index.test.jsx.snap
+++ b/src/containers/WidgetContainers/NoCoursesSidebar/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,9 @@ exports[`WidgetSidebar snapshots default 1`] = `
   <div
     className="d-flex"
   >
-    <RecommendationsPanel />
+    <PluginSlot
+      id="widget_sidebar_plugin_slot"
+    />
   </div>
 </div>
 `;

--- a/src/containers/WidgetContainers/NoCoursesSidebar/index.jsx
+++ b/src/containers/WidgetContainers/NoCoursesSidebar/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
-import RecommendationsPanel from 'widgets/RecommendationsPanel';
 import hooks from 'widgets/ProductRecommendations/hooks';
 
 export const WidgetSidebar = ({ setSidebarShowing }) => {
@@ -13,7 +13,7 @@ export const WidgetSidebar = ({ setSidebarShowing }) => {
     return (
       <div className="widget-sidebar px-2">
         <div className="d-flex">
-          <RecommendationsPanel />
+          <PluginSlot id="widget_sidebar_plugin_slot" />
         </div>
       </div>
     );

--- a/src/containers/WidgetContainers/NoCoursesSidebar/index.test.jsx
+++ b/src/containers/WidgetContainers/NoCoursesSidebar/index.test.jsx
@@ -8,6 +8,9 @@ jest.mock('widgets/LookingForChallengeWidget', () => 'LookingForChallengeWidget'
 jest.mock('widgets/ProductRecommendations/hooks', () => ({
   useShowRecommendationsFooter: jest.fn(),
 }));
+jest.mock('@openedx/frontend-plugin-framework', () => ({
+  PluginSlot: 'PluginSlot',
+}));
 
 describe('WidgetSidebar', () => {
   beforeEach(() => jest.resetAllMocks());


### PR DESCRIPTION
This PR adds two new plugin slots to the widget sidebar, allowing for optional extensibility.

The recommendations panel will move to being rendered via the frontend plugin framework and the new plugin slots.