### PR TITLE
chore: add logging to the github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         subject: CI workflow failed in ${{github.repository}}
         to: masters-grades@edx.org,aperture@2u-internal.opsgenie.net
         from: github-actions <github-actions@edx.org>
+        nodemailerlog: true
+        nodemailerdebug: true
         body: CI workflow in ${{github.repository}} failed!
           For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id
           }}"


### PR DESCRIPTION
* Email sent on CI failure  sometimes has an authentication failure.
* A [recent change to action send mail](https://github.com/dawidd6/action-send-mail/commitŋdc13c734ff2b581c12c1b59958ba73d6fa95b371) added debug logging to the action.
* Enabling the debug logging so we can track this down more easily in the future.

AFFECTS: APER-3092