### PR TITLE
Add fallback image for the course card images

### DIFF
--- a/src/containers/CourseCard/components/CourseCardImage.jsx
+++ b/src/containers/CourseCard/components/CourseCardImage.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { Badge } from '@openedx/paragon';
@@ -15,18 +16,23 @@ const { courseImageClicked } = track.course;
 
 export const CourseCardImage = ({ cardId, orientation }) => {
   const { formatMessage } = useIntl();
+  const [hasImageError, setHasImageError] = useState(false);
   const { bannerImgSrc } = reduxHooks.useCardCourseData(cardId);
   const { homeUrl } = reduxHooks.useCardCourseRunData(cardId);
   const { isVerified } = reduxHooks.useCardEnrollmentData(cardId);
   const { disableCourseTitle } = useActionDisabledState(cardId);
   const handleImageClicked = reduxHooks.useTrackCourseEvent(courseImageClicked, cardId, homeUrl);
   const wrapperClassName = `pgn__card-wrapper-image-cap overflow-visible ${orientation}`;
+  const fallbackImageSrc = `${getConfig().LMS_BASE_URL}/theming/asset/images/no_course_image.png`;
   const image = (
     <>
       <img
         className="pgn__card-image-cap show"
-        src={bannerImgSrc}
+        src={!hasImageError ? bannerImgSrc : fallbackImageSrc}
         alt={formatMessage(messages.bannerAlt)}
+        onError={() => {
+          if (!hasImageError) { setHasImageError(true); }
+        }}
       />
       {
         isVerified && (


### PR DESCRIPTION
When there is no image for course, then the screen shows alt text with broken image icon. This PR fixes it by adding an error image url. The Error image needs to be added in `edx-platform` with name `no_course_image.png`. This works perfectly with even `tutor-indigo` or any theme you want to set using `tutor`.

### Before:
<img width="955" alt="Screenshot 2024-04-22 at 6 07 58 PM" src="https://github.com/openedx/frontend-app-learner-dashboard/assets/112946189/f312f033-930d-4c9e-97b1-d1a66943a0df">

### After:
If the image exists in theme:

<img width="955" alt="Screenshot 2024-04-22 at 6 44 25 PM" src="https://github.com/openedx/frontend-app-learner-dashboard/assets/112946189/2e792d43-1976-47be-83bd-3e2c574f2589">

If the image with name `no_course_image.png` won't exist, then it will show the alt text with broken image icon. 

### Impact:

1. It will enhance user experience
2. It'll maintain consistency of the course card layout
3. Easy to implement with tutor-indigo theme or any customizable theme. Just need to add image with that name.