### PR TITLE
fix: hiding certificate banner for exec ed

### DIFF
--- a/src/containers/CourseCard/components/CourseCardBanners/CertificateBanner.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CertificateBanner.jsx
@@ -18,6 +18,7 @@ export const CertificateBanner = ({ cardId }) => {
   const {
     isAudit,
     isVerified,
+    isExecEd2UCourse,
   } = reduxHooks.useCardEnrollmentData(cardId);
   const { isPassing } = reduxHooks.useCardGradeData(cardId);
   const { isArchived } = reduxHooks.useCardCourseRunData(cardId);
@@ -52,7 +53,7 @@ export const CertificateBanner = ({ cardId }) => {
       </Banner>
     );
   }
-  if (!isPassing) {
+  if (!isPassing && !isExecEd2UCourse) {
     if (isAudit) {
       return (
         <Banner>


### PR DESCRIPTION
[Jira ticket + context ](https://2u-internal.atlassian.net/browse/ENT-8827)

We have a bug that is present for what we assume to be all learners that are taking an exec ed course that shows that a 50% is needed to pass this course, though no actually passing grade is being sent by any exec ed courses. To combat this, we want to hide this banner for all exec ed. 