### PR TITLE
feat: changing ownership for the recommendations widget

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,1 @@
-# Root app is developed and owned by Aurora
 *   @openedx/2U-aperture
-
-# WIDGETS and experiments are developed and owned by separate teams below
-
-# Recommendations panel
-/src/widgets/RecommendationsPanel       @openedx/2U-vanguards
-/src/widgets/LookingForChallengeWidget  @openedx/2U-vanguards


### PR DESCRIPTION
* changing ownership to aperture for this widget  (which is DEPRd  from the open source code base, and aperture is scheduled to remove it at some point).

FIXES: APER-3497