### PR TITLE
chore: remove unused dependency -- axios-mock-adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "@openedx/frontend-build": "14.0.15",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
-        "axios-mock-adapter": "^1.20.0",
         "copy-webpack-plugin": "^12.0.0",
         "husky": "^7.0.0",
         "identity-obj-proxy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@openedx/frontend-build": "14.0.15",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
-    "axios-mock-adapter": "^1.20.0",
     "copy-webpack-plugin": "^12.0.0",
     "husky": "^7.0.0",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
Similarly to #421, the `axios-mock-adapter` dependency is not being used. Renovate is trying to update this from v1.x to 2.x, this PR removes the dependency instead.