### PR TITLE
test: Add Node 20 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,19 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node: [18, 20]
+    continue-on-error: ${{ matrix.node == 20 }}
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Setup Nodejs Env
-      run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
-
     - name: Setup Nodejs
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ env.NODE_VER }}
+        node-version: ${{ matrix.node }}
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
### Description

As a first step in the upgrade to Node 20, add it to the CI matrix as a non-blocking test.

See [the tracking issue](https://github.com/openedx/frontend-app-learner-dashboard/issues/298) for further information.