### PR TITLE
fix: if support page is not set, help button does not appears in header

### DIFF
--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
@@ -56,14 +56,17 @@ export const ExpandedHeader = () => {
           {formatMessage(messages.discoverNew)}
         </Button>
         <span className="flex-grow-1" />
-        <Button
-          as="a"
-          href={getConfig().SUPPORT_URL}
-          variant="inverse-primary"
-          className="p-4"
-        >
-          {formatMessage(messages.help)}
-        </Button>
+        {getConfig().SUPPORT_URL && getConfig().SUPPORT_URL !== ''
+          && (
+            <Button
+              as="a"
+              href={getConfig().SUPPORT_URL}
+              variant="inverse-primary"
+              className="p-4"
+            >
+              {formatMessage(messages.help)}
+            </Button>
+          )}
       </div>
 
       <AuthenticatedUserDropdown />


### PR DESCRIPTION
Fix: if the support page is not set, the help button does not appear in the header

Fixex #373 

**What changed?**

-  If the **SUPPORT PAGE** variable is not set or is empty, the help button does not appear in the header nav. 

![image](https://github.com/user-attachments/assets/b844867b-0eac-40ac-9b81-baed4968fbc3)

**Developer Checklist**

- [x] Test suites passing
- [x] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](https://github.com/openedx/frontend-app-gradebook/package.json)

 
**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x]  I've done a visual code review
- [x]  I've tested the new functionality