### PR TITLE
feat: remove Zendesk component from App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,6 @@ import {
 } from 'data/redux';
 import { reduxHooks } from 'hooks';
 import Dashboard from 'containers/Dashboard';
-import ZendeskFab from 'components/ZendeskFab';
 
 import track from 'tracking';
 
@@ -93,7 +92,6 @@ export const App = () => {
           </main>
         </AppWrapper>
         <FooterSlot />
-        <ZendeskFab />
       </div>
     </>
   );

--- a/src/__snapshots__/App.test.jsx.snap
+++ b/src/__snapshots__/App.test.jsx.snap
@@ -28,7 +28,6 @@ exports[`App router component component initialize failure snapshot 1`] = `
       </main>
     </AppWrapper>
     <FooterSlot />
-    <ZendeskFab />
   </div>
 </Fragment>
 `;
@@ -55,7 +54,6 @@ exports[`App router component component no network failure snapshot 1`] = `
       </main>
     </AppWrapper>
     <FooterSlot />
-    <ZendeskFab />
   </div>
 </Fragment>
 `;
@@ -82,7 +80,6 @@ exports[`App router component component no network failure with optimizely proje
       </main>
     </AppWrapper>
     <FooterSlot />
-    <ZendeskFab />
   </div>
 </Fragment>
 `;
@@ -109,7 +106,6 @@ exports[`App router component component no network failure with optimizely url s
       </main>
     </AppWrapper>
     <FooterSlot />
-    <ZendeskFab />
   </div>
 </Fragment>
 `;
@@ -142,7 +138,6 @@ exports[`App router component component refresh failure snapshot 1`] = `
       </main>
     </AppWrapper>
     <FooterSlot />
-    <ZendeskFab />
   </div>
 </Fragment>
 `;


### PR DESCRIPTION
[APER-3671](https://2u-internal.atlassian.net/browse/APER-3671)
Contributes to #255

This PR removes the automatic use of the ZendeskFab component from the App level. The ZendeskFab logic still lives in the `src/components` directory. 