### PR TITLE
style(CourseCardImage.jsx): img width change to w-100 for safari browser

### DIFF
--- a/src/containers/CourseCard/components/CourseCardImage.jsx
+++ b/src/containers/CourseCard/components/CourseCardImage.jsx
@@ -24,7 +24,7 @@ export const CourseCardImage = ({ cardId, orientation }) => {
   const image = (
     <>
       <img
-        className="pgn__card-image-cap show"
+        className="pgn__card-image-cap show w-100"
         src={bannerImgSrc}
         alt={formatMessage(messages.bannerAlt)}
       />


### PR DESCRIPTION
Fixed img width to w-100 for Safari browser

before:
![img-safari](https://github.com/user-attachments/assets/7799453c-6085-4285-8784-1ecc4b5cbc40)

after:
![img-safari-fix](https://github.com/user-attachments/assets/fbdffc28-7423-411d-8b5f-c14d6bf5cbc8)
