### PR TITLE
fix: update husky

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run lint

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "quality": "npm run lint-fix && npm run test",
     "watch-tests": "jest --watch",
     "snapshot": "fedx-scripts jest --updateSnapshot",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "author": "edX",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Update husky usage based on release [notes from v9](https://github.com/typicode/husky/releases/tag/v9.0.1)

`husky install` is deprecated