### PR TITLE
fix: added LMS_BASE_URL for brand logo

### DIFF
--- a/src/containers/LearnerDashboardHeader/BrandLogo.jsx
+++ b/src/containers/LearnerDashboardHeader/BrandLogo.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import { useContext } from 'react';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 
+import { AppContext } from '@edx/frontend-platform/react';
 import { reduxHooks } from 'hooks';
 
 import { getConfig } from '@edx/frontend-platform';
@@ -10,9 +11,10 @@ import messages from './messages';
 export const BrandLogo = () => {
   const { formatMessage } = useIntl();
   const dashboard = reduxHooks.useEnterpriseDashboardData();
+  const { config } = useContext(AppContext);
 
   return (
-    <a href={dashboard?.url || '/'} className="mx-auto">
+    <a href={dashboard?.url || config.LMS_BASE_URL} className="mx-auto">
       <img
         className="logo py-3"
         src={getConfig().LOGO_URL}

--- a/src/containers/LearnerDashboardHeader/BrandLogo.jsx
+++ b/src/containers/LearnerDashboardHeader/BrandLogo.jsx
@@ -1,8 +1,5 @@
-import { useContext } from 'react';
-
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import { AppContext } from '@edx/frontend-platform/react';
 import { reduxHooks } from 'hooks';
 
 import { getConfig } from '@edx/frontend-platform';
@@ -11,10 +8,9 @@ import messages from './messages';
 export const BrandLogo = () => {
   const { formatMessage } = useIntl();
   const dashboard = reduxHooks.useEnterpriseDashboardData();
-  const { config } = useContext(AppContext);
 
   return (
-    <a href={dashboard?.url || config.LMS_BASE_URL} className="mx-auto">
+    <a href={dashboard?.url || getConfig().LMS_BASE_URL} className="mx-auto">
       <img
         className="logo py-3"
         src={getConfig().LOGO_URL}

--- a/src/containers/LearnerDashboardHeader/BrandLogo.test.jsx
+++ b/src/containers/LearnerDashboardHeader/BrandLogo.test.jsx
@@ -9,6 +9,14 @@ jest.mock('hooks', () => ({
   },
 }));
 
+jest.mock('@edx/frontend-platform/react', () => ({
+  AppContext: {
+    config: {
+      LMS_BASE_URL: '/',
+    },
+  },
+}));
+
 describe('BrandLogo', () => {
   test('dashboard defined', () => {
     reduxHooks.useEnterpriseDashboardData.mockReturnValueOnce({

--- a/src/containers/LearnerDashboardHeader/BrandLogo.test.jsx
+++ b/src/containers/LearnerDashboardHeader/BrandLogo.test.jsx
@@ -1,19 +1,12 @@
 import { shallow } from '@edx/react-unit-test-utils';
-
+import { getConfig } from '@edx/frontend-platform';
 import { reduxHooks } from 'hooks';
+
 import BrandLogo from './BrandLogo';
 
 jest.mock('hooks', () => ({
   reduxHooks: {
     useEnterpriseDashboardData: jest.fn(),
-  },
-}));
-
-jest.mock('@edx/frontend-platform/react', () => ({
-  AppContext: {
-    config: {
-      LMS_BASE_URL: '/',
-    },
   },
 }));
 
@@ -31,6 +24,6 @@ describe('BrandLogo', () => {
     reduxHooks.useEnterpriseDashboardData.mockReturnValueOnce(null);
     const wrapper = shallow(<BrandLogo />);
     expect(wrapper.snapshot).toMatchSnapshot();
-    expect(wrapper.instance.findByType('a')[0].props.href).toEqual('/');
+    expect(wrapper.instance.findByType('a')[0].props.href).toEqual(getConfig().LMS_BASE_URL);
   });
 });

--- a/src/containers/LearnerDashboardHeader/__snapshots__/BrandLogo.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/__snapshots__/BrandLogo.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`BrandLogo dashboard defined 1`] = `
 exports[`BrandLogo dashboard undefined 1`] = `
 <a
   className="mx-auto"
-  href="/"
+  href="http://localhost:18000"
 >
   <img
     alt="edX, Inc. Dashboard"


### PR DESCRIPTION
![Warning](https://img.shields.io/badge/Warning-redwood.master-orange?style=flat-square)

**Description**
This PR includes changes to the `BrandLogo` component in the `LearnerDashboardHeader` to improve its functionality and testing.

**Changes**
- replaced '/' to LMS_BASE_URL if dashboard url does not provided
- updated tests

**Quick demo**

https://github.com/user-attachments/assets/bec02d00-88d4-454d-96e8-1a0e5bdc446b