### PR TITLE
Revert "fix: display programs only if the url is configured (#479)"

### DIFF
--- a/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
+++ b/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
@@ -9,7 +9,6 @@ const getLearnerHeaderMenu = (
   courseSearchUrl,
   authenticatedUser,
   exploreCoursesClick,
-  programsEnabled = false,
 ) => ({
   mainMenu: [
     {
@@ -18,11 +17,11 @@ const getLearnerHeaderMenu = (
       content: formatMessage(messages.course),
       isActive: true,
     },
-    ...(programsEnabled ? [{
+    {
       type: 'item',
       href: `${urls.programsUrl()}`,
       content: formatMessage(messages.program),
-    }] : []),
+    },
     {
       type: 'item',
       href: `${urls.baseAppUrl(courseSearchUrl)}`,

--- a/src/containers/LearnerDashboardHeader/__snapshots__/index.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/__snapshots__/index.test.jsx.snap
@@ -13,6 +13,11 @@ exports[`LearnerDashboardHeader render 1`] = `
           "type": "item",
         },
         {
+          "content": "Programs",
+          "href": "http://localhost:18000/dashboard/programs",
+          "type": "item",
+        },
+        {
           "content": "Discover New",
           "href": "http://localhost:18000/course-search-url",
           "onClick": [Function],

--- a/src/containers/LearnerDashboardHeader/hooks.js
+++ b/src/containers/LearnerDashboardHeader/hooks.js
@@ -5,7 +5,6 @@ import track from 'tracking';
 import { StrictDict } from 'utils';
 import { linkNames } from 'tracking/constants';
 
-import { apiHooks } from 'hooks';
 import getLearnerHeaderMenu from './LearnerDashboardMenu';
 
 import * as module from './hooks';
@@ -31,9 +30,8 @@ export const findCoursesNavDropdownClicked = (href) => track.findCourses.findCou
 export const useLearnerDashboardHeaderMenu = ({
   courseSearchUrl, authenticatedUser, exploreCoursesClick,
 }) => {
-  const { enabled: programsEnabled } = apiHooks.useProgramsConfig();
   const { formatMessage } = useIntl();
-  return getLearnerHeaderMenu(formatMessage, courseSearchUrl, authenticatedUser, exploreCoursesClick, programsEnabled);
+  return getLearnerHeaderMenu(formatMessage, courseSearchUrl, authenticatedUser, exploreCoursesClick);
 };
 
 export const useLearnerDashboardHeaderData = () => {

--- a/src/containers/LearnerDashboardHeader/hooks.test.js
+++ b/src/containers/LearnerDashboardHeader/hooks.test.js
@@ -21,11 +21,6 @@ jest.mock('tracking', () => ({
     findCoursesClicked: jest.fn(),
   },
 }));
-jest.mock('hooks', () => ({
-  apiHooks: {
-    useProgramsConfig: jest.fn(() => ({})),
-  },
-}));
 
 const url = 'http://example.com';
 
@@ -61,7 +56,7 @@ describe('LearnerDashboardHeader hooks', () => {
         username: 'test',
       };
       const learnerHomeHeaderMenu = useLearnerDashboardHeaderMenu({ courseSearchUrl, authenticatedUser });
-      expect(learnerHomeHeaderMenu.mainMenu.length).toBe(2);
+      expect(learnerHomeHeaderMenu.mainMenu.length).toBe(3);
     });
   });
 

--- a/src/containers/LearnerDashboardHeader/index.test.jsx
+++ b/src/containers/LearnerDashboardHeader/index.test.jsx
@@ -3,7 +3,6 @@ import { shallow } from '@edx/react-unit-test-utils';
 import Header from '@edx/frontend-component-header';
 
 import urls from 'data/services/lms/urls';
-import { apiHooks } from 'hooks';
 import LearnerDashboardHeader from '.';
 import { findCoursesNavClicked } from './hooks';
 
@@ -12,9 +11,6 @@ jest.mock('hooks', () => ({
     usePlatformSettingsData: jest.fn(() => ({
       courseSearchUrl: '/course-search-url',
     })),
-  },
-  apiHooks: {
-    useProgramsConfig: jest.fn(() => ({})),
   },
 }));
 jest.mock('./hooks', () => ({
@@ -33,7 +29,7 @@ describe('LearnerDashboardHeader', () => {
     expect(wrapper.instance.findByType('ConfirmEmailBanner')).toHaveLength(1);
     expect(wrapper.instance.findByType('MasqueradeBar')).toHaveLength(1);
     expect(wrapper.instance.findByType(Header)).toHaveLength(1);
-    wrapper.instance.findByType(Header)[0].props.mainMenuItems[1].onClick();
+    wrapper.instance.findByType(Header)[0].props.mainMenuItems[2].onClick();
     expect(findCoursesNavClicked).toHaveBeenCalledWith(urls.baseAppUrl('/course-search-url'));
     expect(wrapper.instance.findByType(Header)[0].props.secondaryMenuItems.length).toBe(0);
   });
@@ -42,11 +38,5 @@ describe('LearnerDashboardHeader', () => {
     mergeConfig({ SUPPORT_URL: 'http://localhost:18000/support' });
     const wrapper = shallow(<LearnerDashboardHeader />);
     expect(wrapper.instance.findByType(Header)[0].props.secondaryMenuItems.length).toBe(1);
-    expect(wrapper.instance.findByType(Header)[0].props.mainMenuItems.length).toBe(2);
-  });
-  test('should display Programs link if the service is configured in the backend', () => {
-    apiHooks.useProgramsConfig.mockReturnValue({ enabled: true });
-    const wrapper = shallow(<LearnerDashboardHeader />);
-    expect(wrapper.instance.findByType(Header)[0].props.mainMenuItems.length).toBe(3);
   });
 });

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -20,8 +20,6 @@ export const initializeList = ({ user } = {}) => get(
   stringifyUrl(urls.getInitApiUrl(), { [apiKeys.user]: user }),
 );
 
-export const getProgramsConfig = () => get(urls.programsConfigUrl());
-
 export const updateEntitlementEnrollment = ({ uuid, courseId }) => post(
   urls.entitlementEnrollment(uuid),
   { [apiKeys.courseRunId]: courseId },
@@ -75,7 +73,6 @@ export const createCreditRequest = ({ providerId, courseId, username }) => post(
 
 export default {
   initializeList,
-  getProgramsConfig,
   unenrollFromCourse,
   updateEmailSettings,
   updateEntitlementEnrollment,

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -22,7 +22,6 @@ export const baseAppUrl = (url) => updateUrl(getBaseUrl(), url);
 export const learningMfeUrl = (url) => updateUrl(getConfig().LEARNING_BASE_URL, url);
 
 // static view url
-const programsConfigUrl = () => baseAppUrl('/config/programs');
 const programsUrl = () => baseAppUrl('/dashboard/programs');
 
 export const creditPurchaseUrl = (courseId) => `${getEcommerceUrl()}/credit/checkout/${courseId}/`;
@@ -38,7 +37,6 @@ export default StrictDict({
   event,
   getInitApiUrl,
   learningMfeUrl,
-  programsConfigUrl,
   programsUrl,
   updateEmailSettings,
 });

--- a/src/hooks/api.js
+++ b/src/hooks/api.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { logError } from '@edx/frontend-platform/logging';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { RequestKeys } from 'data/constants/requests';
@@ -30,25 +29,6 @@ export const useInitializeApp = () => {
     requestKey: RequestKeys.initialize,
     onSuccess: ({ data }) => loadData(data),
   });
-};
-
-export const useProgramsConfig = () => {
-  const [config, setConfig] = React.useState({});
-
-  React.useEffect(() => {
-    const fetchProgramsConfig = async () => {
-      try {
-        const { data } = await api.getProgramsConfig();
-        setConfig(data);
-      } catch (error) {
-        logError(`Error accessing programs configuration ${error}`);
-      }
-    };
-
-    fetchProgramsConfig();
-  }, []);
-
-  return config;
 };
 
 export const useNewEntitlementEnrollment = (cardId) => {

--- a/src/hooks/api.test.js
+++ b/src/hooks/api.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { logError } from '@edx/frontend-platform/logging';
 import { AppContext } from '@edx/frontend-platform/react';
 import { keyStore } from 'utils';
 import { RequestKeys } from 'data/constants/requests';
@@ -11,14 +10,9 @@ import * as apiHooks from './api';
 
 const reduxKeys = keyStore(reduxHooks);
 
-jest.mock('@edx/frontend-platform/logging', () => ({
-  logError: jest.fn(),
-}));
-
 jest.mock('data/services/lms/utils', () => ({
   post: jest.fn((...args) => ({ post: args })),
 }));
-
 jest.mock('data/services/lms/api', () => ({
   initializeList: jest.fn(),
   updateEntitlementEnrollment: jest.fn(),
@@ -26,9 +20,7 @@ jest.mock('data/services/lms/api', () => ({
   deleteEntitlementEnrollment: jest.fn(),
   updateEmailSettings: jest.fn(),
   createCreditRequest: jest.fn(),
-  getProgramsConfig: jest.fn(),
 }));
-
 jest.mock('data/redux/hooks', () => ({
   useCardCourseRunData: jest.fn(),
   useCardCreditData: jest.fn(),
@@ -115,34 +107,6 @@ describe('api hooks', () => {
       it('calls loadData with data on success', () => {
         hook.args.onSuccess({ data: testString });
         expect(loadData).toHaveBeenCalledWith(testString);
-      });
-    });
-
-    describe('useProgramsConfig', () => {
-      let mockState;
-      const setState = jest.fn((newState) => { Object.assign(mockState, newState); });
-      beforeEach(() => {
-        mockState = {};
-        React.useState.mockReturnValue([mockState, setState]);
-      });
-
-      it('should return the programs configuration when the API call is successful', async () => {
-        api.getProgramsConfig.mockResolvedValue({ data: { enabled: true } });
-        const config = apiHooks.useProgramsConfig();
-        const [cb] = React.useEffect.mock.calls[0];
-        await cb();
-        expect(setState).toHaveBeenCalled();
-        expect(config).toEqual({ enabled: true });
-      });
-
-      it('should return an empty object if the api call fails', async () => {
-        mockState = {};
-        api.getProgramsConfig.mockRejectedValue(new Error('error test'));
-        const config = apiHooks.useProgramsConfig();
-        const [cb] = React.useEffect.mock.calls[0];
-        await cb();
-        expect(config).toEqual({});
-        expect(logError).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
This reverts commit e8886c9d9d98f65ec31fe5e7fd7de6c3926c2827.

I'm going to roll this back, it is broken in a live (ie. non-development) environment with real users. The code determines if programs is active by `baseAppUrl('/config/programs');`.  [The URL is permissioned](https://github.com/openedx/django-config-models/blob/32c885d92131fcac1680c518c6f8a127a67f5e2e/config_models/views.py#L42-L52) and is inaccessible  under production circumstances. This will need another method. Possibilities: a URL that's reachable by any logged in user, or a server-side check, or looking to see if this is exposed via a standard config setting. (That last would be ideal.)

The automated tests should also make sure they are using a non-permissioned user, if we have that functionality in jest.