### PR TITLE
fix: fixed module button href

### DIFF
--- a/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
+++ b/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
@@ -31,7 +31,7 @@ export const CollapseMenuBody = ({ isOpen }) => {
 
   return (
     <div className="d-flex flex-column shadow-sm nav-small-menu">
-      <Button as="a" href="/" variant="inverse-primary">
+      <Button as="a" href={`${getConfig().LMS_BASE_URL}/dashboard/`} variant="inverse-primary">
         {formatMessage(messages.course)}
       </Button>
       {programsEnabled && (

--- a/src/containers/LearnerDashboardHeader/CollapsedHeader/__snapshots__/CollapseMenuBody.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/CollapsedHeader/__snapshots__/CollapseMenuBody.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`CollapseMenuBody render 1`] = `
 >
   <Button
     as="a"
-    href="/"
+    href="http://localhost:18000/dashboard/"
     variant="inverse-primary"
   >
     Courses
@@ -74,7 +74,7 @@ exports[`CollapseMenuBody render unauthenticated 1`] = `
 >
   <Button
     as="a"
-    href="/"
+    href="http://localhost:18000/dashboard/"
     variant="inverse-primary"
   >
     Courses
@@ -110,7 +110,7 @@ exports[`CollapseMenuBody render with disabled programs 1`] = `
 >
   <Button
     as="a"
-    href="/"
+    href="http://localhost:18000/dashboard/"
     variant="inverse-primary"
   >
     Courses

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/__snapshots__/index.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/__snapshots__/index.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`ExpandedHeader render 1`] = `
     <Button
       as="a"
       className="p-4 course-link"
-      href="/"
+      href="http://localhost:18000/dashboard/"
       variant="inverse-primary"
     >
       Courses
@@ -62,7 +62,7 @@ exports[`ExpandedHeader render with disabled programs 1`] = `
     <Button
       as="a"
       className="p-4 course-link"
-      href="/"
+      href="http://localhost:18000/dashboard/"
       variant="inverse-primary"
     >
       Courses

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
@@ -34,7 +34,7 @@ export const ExpandedHeader = () => {
 
         <Button
           as="a"
-          href="/"
+          href={`${getConfig().LMS_BASE_URL}/dashboard/`}
           variant="inverse-primary"
           className="p-4 course-link"
         >


### PR DESCRIPTION
![Warning](https://img.shields.io/badge/Warning-redwood.master-orange?style=flat-square)

**Description**

This PR includes changes to update the URLs in the `LearnerDashboardHeader` components to use the configured LMS base URL instead of hardcoded paths. This ensures that the application correctly redirects to the dashboard in different environments.

https://github.com/user-attachments/assets/6b5e81b7-0f93-44ad-a03b-390a7e847e2b