### PR TITLE
fix: Use browserslist-config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-        "@edx/browserslist-config": "^1.1.0",
         "@edx/frontend-component-header": "^5.6.0",
         "@edx/frontend-enterprise-hotjar": "7.1.0",
         "@edx/frontend-platform": "8.1.2",
@@ -51,6 +50,7 @@
         "util": "^0.12.4"
       },
       "devDependencies": {
+        "@edx/browserslist-config": "^1.3.0",
         "@edx/reactifex": "^2.1.1",
         "@openedx/frontend-build": "14.2.0",
         "@testing-library/jest-dom": "^5.14.1",
@@ -2040,9 +2040,10 @@
       "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@edx/browserslist-config": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.2.0.tgz",
-      "integrity": "sha512-T1+6P52Yx7SMkmoIr4O0Q3m/DyRdrLTJbv1xVijdRLFEq1hqdafEs+Ln1423U5LSkTePb9AOkEtL1G0RZLFl1w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.3.0.tgz",
+      "integrity": "sha512-qf4BHyjdsx/bVMQmfj1y/MwTZwI5+9DAOul+PJnyO+YhWSwdxtdvXqkOw1wLxqmDtqOPc5bYgDQf8zZfe+aDFA==",
+      "license": "AGPL-3.0"
     },
     "node_modules/@edx/eslint-config": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git+https://github.com/edx/frontend-app-learner-dashboard.git"
   },
+  "browserslist": [
+    "extends @edx/browserslist-config"
+  ],
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "fedx-scripts formatjs extract",
@@ -27,7 +30,6 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-    "@edx/browserslist-config": "^1.1.0",
     "@edx/frontend-component-header": "^5.6.0",
     "@edx/frontend-enterprise-hotjar": "7.1.0",
     "@edx/frontend-platform": "8.1.2",
@@ -68,6 +70,7 @@
     "util": "^0.12.4"
   },
   "devDependencies": {
+    "@edx/browserslist-config": "^1.3.0",
     "@edx/reactifex": "^2.1.1",
     "@openedx/frontend-build": "14.2.0",
     "@testing-library/jest-dom": "^5.14.1",


### PR DESCRIPTION
We were installing browserslist-config but not declaring it.  This had the effect that webpack - and likely others - were not using it.
