### PR TITLE
feat: remove upgrade button [Sumac]

### DIFF
--- a/src/plugin-slots/CourseCardActionSlot/index.jsx
+++ b/src/plugin-slots/CourseCardActionSlot/index.jsx
@@ -2,27 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
-import { reduxHooks } from 'hooks';
-import UpgradeButton from 'containers/CourseCard/components/CourseCardActions/UpgradeButton';
-
-const CourseCardActionSlot = ({ cardId }) => {
-  const { isEntitlement } = reduxHooks.useCardEntitlementData(cardId);
-  const {
-    isVerified,
-    isExecEd2UCourse,
-  } = reduxHooks.useCardEnrollmentData(cardId);
-
-  return (
-    <PluginSlot
-      id="course_card_action_slot"
-      pluginProps={{
-        cardId,
-      }}
-    >
-      {!(isEntitlement || isVerified || isExecEd2UCourse) && <UpgradeButton cardId={cardId} />}
-    </PluginSlot>
-  );
-};
+const CourseCardActionSlot = ({ cardId }) => (
+  <PluginSlot
+    id="course_card_action_slot"
+    pluginProps={{
+      cardId,
+    }}
+  />
+);
 
 CourseCardActionSlot.propTypes = {
   cardId: PropTypes.string.isRequired,


### PR DESCRIPTION
(This is a Sumac-specific change!)

### Description

This removes the upgrade button as default content in CourseCardActionSlot.

This is, for the moment, a Sumac-specific change.  The button is still present in master, pending proper removal (including the component definitions from the rest of the repository) prior to the U release by the maintainers.  See:

https://github.com/openedx/frontend-app-learner-dashboard/issues/438

### Screenshots

Before:

![image](https://github.com/user-attachments/assets/2e0f3d57-bbf6-47b3-a872-f29af84fd823)

After:

![image](https://github.com/user-attachments/assets/9013d192-dded-4cb9-921c-c6712a310b60)