### PR TITLE
chore: add `dev` script to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint-fix": "fedx-scripts eslint --fix --ext .jsx,.js src/",
     "semantic-release": "semantic-release",
     "start": "fedx-scripts webpack-dev-server --progress",
+    "dev": "PUBLIC_PATH=/learner-dashboard/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "TZ=GMT fedx-scripts jest --coverage --passWithNoTests",
     "quality": "npm run lint-fix && npm run test",
     "watch-tests": "jest --watch",


### PR DESCRIPTION
This allows development against tutor by running `npm run dev`

Following the pattern from https://github.com/openedx/frontend-app-learning/blob/master/package.json#L22