### PR TITLE
fix: make enterprise modal blocking

### DIFF
--- a/src/containers/EnterpriseDashboardModal/__snapshots__/index.test.jsx.snap
+++ b/src/containers/EnterpriseDashboardModal/__snapshots__/index.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`EnterpriseDashboard empty snapshot 1`] = `null`;
 exports[`EnterpriseDashboard snapshot 1`] = `
 <ModalDialog
   hasCloseButton={false}
+  isBlocking={true}
   onClose={[MockFunction useEnterpriseDashboardHook.handleEscape]}
   title=""
 >

--- a/src/containers/EnterpriseDashboardModal/index.jsx
+++ b/src/containers/EnterpriseDashboardModal/index.jsx
@@ -23,6 +23,7 @@ export const EnterpriseDashboardModal = () => {
   }
   return (
     <ModalDialog
+      isBlocking
       isOpen={showModal}
       onClose={handleEscape}
       hasCloseButton={false}


### PR DESCRIPTION
Verizon requested that the modal that attempts to direct learners to the enterprise dashboard have to be either accepted or dismissed instead of being able to click out of it. 

[Jira ticket 
](https://2u-internal.atlassian.net/browse/ENT-9853)

<img width="467" alt="Screenshot 2025-01-15 at 11 24 21 PM" src="https://github.com/user-attachments/assets/c652f7a3-f186-43de-a16c-dfe31ab88799" />
