### PR TITLE
fix: course image height on IOS Safari

### DIFF
--- a/src/containers/CourseCard/components/CourseCardImage.jsx
+++ b/src/containers/CourseCard/components/CourseCardImage.jsx
@@ -20,11 +20,13 @@ export const CourseCardImage = ({ cardId, orientation }) => {
   const { isVerified } = reduxHooks.useCardEnrollmentData(cardId);
   const { disableCourseTitle } = useActionDisabledState(cardId);
   const handleImageClicked = reduxHooks.useTrackCourseEvent(courseImageClicked, cardId, homeUrl);
-  const wrapperClassName = `pgn__card-wrapper-image-cap overflow-visible ${orientation}`;
+  const wrapperClassName = `pgn__card-wrapper-image-cap d-inline-block overflow-visible ${orientation}`;
   const image = (
     <>
       <img
-        className="pgn__card-image-cap show"
+        // w-100 is necessary for images on Safari, otherwise stretches full height of the image
+        // https://stackoverflow.com/a/44250830
+        className="pgn__card-image-cap w-100 show"
         src={bannerImgSrc}
         alt={formatMessage(messages.bannerAlt)}
       />

--- a/src/containers/CourseCard/components/__snapshots__/CourseCardImage.test.jsx.snap
+++ b/src/containers/CourseCard/components/__snapshots__/CourseCardImage.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CourseCardImage snapshot renders clickable link course Image 1`] = `
 <a
-  className="pgn__card-wrapper-image-cap overflow-visible orientation"
+  className="pgn__card-wrapper-image-cap d-inline-block overflow-visible orientation"
   href="home-url"
   onClick={
     {
@@ -18,7 +18,7 @@ exports[`CourseCardImage snapshot renders clickable link course Image 1`] = `
   <Fragment>
     <img
       alt="Course thumbnail"
-      className="pgn__card-image-cap show"
+      className="pgn__card-image-cap w-100 show"
       src="banner-img-src"
     />
     <span
@@ -43,12 +43,12 @@ exports[`CourseCardImage snapshot renders clickable link course Image 1`] = `
 
 exports[`CourseCardImage snapshot renders disabled link 1`] = `
 <div
-  className="pgn__card-wrapper-image-cap overflow-visible orientation"
+  className="pgn__card-wrapper-image-cap d-inline-block overflow-visible orientation"
 >
   <Fragment>
     <img
       alt="Course thumbnail"
-      className="pgn__card-image-cap show"
+      className="pgn__card-image-cap w-100 show"
       src="banner-img-src"
     />
     <span


### PR DESCRIPTION
### Description

Closes https://github.com/openedx/frontend-app-learner-dashboard/issues/265.

Course thumbnails on IOS Safari stretch to the full height of the image, instead of being limited by width and preserving aspect ratio. This seems to be a IOS Safari specific behavior[1], and can be fixed by setting height to auto, while width is set to 100%.

This issues is specific to the context of the course card, so we are fixing it by setting the height in the course card css, instead of fixing it globally in the Paragon styles, which wouldn't work in all contexts.

1: https://stackoverflow.com/a/44250830

### Screenshots

Screenshots taken from an iPhone of the same course on the course dashboard before and after the fix. Course name censored for privacy.

<details> 
  <summary>Before</summary>
  <img src="https://github.com/user-attachments/assets/f6a942c6-be96-48d1-ae77-7b1fe8fd48f6">
</details>
<details> 
  <summary>After</summary>
  <img src="https://github.com/user-attachments/assets/802032a7-213d-4c40-8edf-a05683d3f1fc">
</details>
