### PR TITLE
feat: remove upgrade refs course banner

### DIFF
--- a/src/containers/CourseCard/components/CourseCardBanners/CourseBanner.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CourseBanner.jsx
@@ -12,7 +12,6 @@ export const CourseBanner = ({ cardId }) => {
   const {
     isVerified,
     isAuditAccessExpired,
-    canUpgrade,
     coursewareAccess = {},
   } = reduxHooks.useCardEnrollmentData(cardId);
   const courseRun = reduxHooks.useCardCourseRunData(cardId);
@@ -26,13 +25,7 @@ export const CourseBanner = ({ cardId }) => {
   return (
     <>
       {isAuditAccessExpired
-        && (canUpgrade ? (
-          <Banner>
-            {formatMessage(messages.auditAccessExpired)}
-            {'  '}
-            {formatMessage(messages.upgradeToAccess)}
-          </Banner>
-        ) : (
+        && (
           <Banner>
             {formatMessage(messages.auditAccessExpired)}
             {'  '}
@@ -40,17 +33,7 @@ export const CourseBanner = ({ cardId }) => {
               {formatMessage(messages.findAnotherCourse)}
             </Hyperlink>
           </Banner>
-        ))}
-
-      {courseRun.isActive && !canUpgrade && (
-        <Banner>
-          {formatMessage(messages.upgradeDeadlinePassed)}
-          {'  '}
-          <Hyperlink isInline destination={courseRun.marketingUrl || ''}>
-            {formatMessage(messages.exploreCourseDetails)}
-          </Hyperlink>
-        </Banner>
-      )}
+        )}
 
       {(!isStaff && isTooEarly && courseRun.startDate) && (
         <Banner>
@@ -59,6 +42,7 @@ export const CourseBanner = ({ cardId }) => {
           })}
         </Banner>
       )}
+
       {(!isStaff && hasUnmetPrerequisites) && (
         <Banner>{formatMessage(messages.prerequisitesNotMet)}</Banner>
       )}

--- a/src/containers/CourseCard/components/CourseCardBanners/CourseBanner.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CourseBanner.test.jsx
@@ -25,7 +25,6 @@ let el;
 
 const enrollmentData = {
   isVerified: false,
-  canUpgrade: false,
   isAuditAccessExpired: false,
   coursewareAccess: {
     hasUnmetPrerequisites: false,
@@ -65,18 +64,6 @@ describe('CourseBanner', () => {
     render({ enrollment: { isVerified: true } });
     expect(el.isEmptyRender()).toEqual(true);
   });
-  describe('audit access expired, can upgrade', () => {
-    beforeEach(() => {
-      render({ enrollment: { isAuditAccessExpired: true, canUpgrade: true } });
-    });
-    test('snapshot: (auditAccessExpired, upgradeToAccess)', () => {
-      expect(el.snapshot).toMatchSnapshot();
-    });
-    test('messages: (auditAccessExpired, upgradeToAccess)', () => {
-      expect(el.instance.children[0].children[0].el).toContain(messages.auditAccessExpired.defaultMessage);
-      expect(el.instance.children[0].children[2].el).toContain(messages.upgradeToAccess.defaultMessage);
-    });
-  });
   describe('audit access expired, cannot upgrade', () => {
     beforeEach(() => {
       render({ enrollment: { isAuditAccessExpired: true } });
@@ -88,27 +75,6 @@ describe('CourseBanner', () => {
       expect(el.instance.children[0].children[0].el).toContain(messages.auditAccessExpired.defaultMessage);
       expect(el.instance.findByType(Hyperlink)[0].children[0].el).toEqual(messages.findAnotherCourse.defaultMessage);
     });
-  });
-  describe('course run active and cannot upgrade', () => {
-    beforeEach(() => {
-      render({ courseRun: { isActive: true } });
-    });
-    test('snapshot: (upgradseDeadlinePassed, exploreCourseDetails hyperlink)', () => {
-      expect(el.snapshot).toMatchSnapshot();
-    });
-    test('messages: (upgradseDeadlinePassed, exploreCourseDetails hyperlink)', () => {
-      expect(el.instance.children[0].children[0].el).toContain(messages.upgradeDeadlinePassed.defaultMessage);
-      const link = el.instance.findByType(Hyperlink);
-      expect(link[0].children[0].el).toEqual(messages.exploreCourseDetails.defaultMessage);
-      expect(link[0].props.destination).toEqual(courseRunData.marketingUrl);
-    });
-  });
-  test('no display if audit access not expired and (course is not active or can upgrade)', () => {
-    render();
-    // isEmptyRender() isn't true because the minimal is <Fragment />
-    expect(el.instance.children).toEqual([]);
-    render({ enrollment: { canUpgrade: true }, courseRun: { isActive: true } });
-    expect(el.instance.children).toEqual([]);
   });
   describe('unmet prerequisites', () => {
     beforeEach(() => {

--- a/src/containers/CourseCard/components/CourseCardBanners/CourseBanner.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CourseBanner.test.jsx
@@ -64,14 +64,14 @@ describe('CourseBanner', () => {
     render({ enrollment: { isVerified: true } });
     expect(el.isEmptyRender()).toEqual(true);
   });
-  describe('audit access expired, cannot upgrade', () => {
+  describe('audit access expired', () => {
     beforeEach(() => {
       render({ enrollment: { isAuditAccessExpired: true } });
     });
     test('snapshot: (auditAccessExpired, findAnotherCourse hyperlink)', () => {
       expect(el.snapshot).toMatchSnapshot();
     });
-    test('messages: (auditAccessExpired, upgradeToAccess)', () => {
+    test('messages: auditAccessExpired', () => {
       expect(el.instance.children[0].children[0].el).toContain(messages.auditAccessExpired.defaultMessage);
       expect(el.instance.findByType(Hyperlink)[0].children[0].el).toEqual(messages.findAnotherCourse.defaultMessage);
     });

--- a/src/containers/CourseCard/components/CourseCardBanners/__snapshots__/CourseBanner.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardBanners/__snapshots__/CourseBanner.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CourseBanner audit access expired, cannot upgrade snapshot: (auditAccessExpired, findAnotherCourse hyperlink) 1`] = `
+exports[`CourseBanner audit access expired snapshot: (auditAccessExpired, findAnotherCourse hyperlink) 1`] = `
 <Fragment>
   <Banner>
     Your audit access to this course has expired.

--- a/src/containers/CourseCard/components/CourseCardBanners/__snapshots__/CourseBanner.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardBanners/__snapshots__/CourseBanner.test.jsx.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CourseBanner audit access expired, can upgrade snapshot: (auditAccessExpired, upgradeToAccess) 1`] = `
-<Fragment>
-  <Banner>
-    Your audit access to this course has expired.
-      
-    Upgrade now to access your course again.
-  </Banner>
-</Fragment>
-`;
-
 exports[`CourseBanner audit access expired, cannot upgrade snapshot: (auditAccessExpired, findAnotherCourse hyperlink) 1`] = `
 <Fragment>
   <Banner>
@@ -20,21 +10,6 @@ exports[`CourseBanner audit access expired, cannot upgrade snapshot: (auditAcces
       isInline={true}
     >
       Find another course
-    </Hyperlink>
-  </Banner>
-</Fragment>
-`;
-
-exports[`CourseBanner course run active and cannot upgrade snapshot: (upgradseDeadlinePassed, exploreCourseDetails hyperlink) 1`] = `
-<Fragment>
-  <Banner>
-    Your upgrade deadline for this course has passed.  To upgrade, enroll in a session that is farther in the future.
-      
-    <Hyperlink
-      destination="marketing-url"
-      isInline={true}
-    >
-      Explore course details.
     </Hyperlink>
   </Banner>
 </Fragment>

--- a/src/containers/CourseCard/components/CourseCardBanners/messages.js
+++ b/src/containers/CourseCard/components/CourseCardBanners/messages.js
@@ -6,25 +6,10 @@ const messages = defineMessages({
     description: 'Audit access expiration banner message',
     defaultMessage: 'Your audit access to this course has expired.',
   },
-  upgradeToAccess: {
-    id: 'learner-dash.courseCard.banners.upgradeToAccess',
-    description: 'Upgrade prompt for audit-expired learners that can still upgrade',
-    defaultMessage: 'Upgrade now to access your course again.',
-  },
   findAnotherCourse: {
     id: 'learner-dash.courseCard.banners.findAnotherCourse',
     description: 'Action prompt taking learners to course exploration',
     defaultMessage: 'Find another course',
-  },
-  upgradeDeadlinePassed: {
-    id: 'learner-dash.courseCard.banners.upgradeDeadlinePassed',
-    description: 'Audit upgrade deadline passed banner message',
-    defaultMessage: 'Your upgrade deadline for this course has passed.  To upgrade, enroll in a session that is farther in the future.',
-  },
-  exploreCourseDetails: {
-    id: 'learner-dash.courseCard.banners.exploreCourseDetails',
-    description: 'Action prompt taking learners to course details page',
-    defaultMessage: 'Explore course details.',
   },
   certRestricted: {
     id: 'learner-dash.courseCard.banners.certificateRestricted',


### PR DESCRIPTION
This removes references to the upgrade functionality in the `CourseBanner` component. The `CourseBanner` component will render alerts underneath each `CourseCard` to indicate certain states that the enrollment is in. Some of these alerts were referring to the `canUpgrade` boolean from redux store to determine their layout. Any of those alerts that reference upgrades/upgrading an enrollment have been removed in this PR.