### PR TITLE
fix: rename course banner slot

### DIFF
--- a/src/plugin-slots/CourseBannerSlot/README.md
+++ b/src/plugin-slots/CourseBannerSlot/README.md
@@ -28,7 +28,7 @@ const config = {
         {
           op: PLUGIN_OPERATIONS.Insert,
           widget: {
-            id: 'custom_course_banner',
+            id: 'org.openedx.frontend.learner_dashboard.course_card_banner.v1',
             type: DIRECT_PLUGIN,
             priority: 60,
             RenderWidget: ({ cardId }) => (

--- a/src/plugin-slots/CourseBannerSlot/index.jsx
+++ b/src/plugin-slots/CourseBannerSlot/index.jsx
@@ -5,7 +5,7 @@ import CourseBanner from 'containers/CourseCard/components/CourseCardBanners/Cou
 
 const CourseBannerSlot = ({ cardId }) => (
   <PluginSlot
-    id="course_banner_slot"
+    id="org.openedx.frontend.learner_dashboard.course_card_banner.v1"
     pluginProps={{
       cardId,
     }}


### PR DESCRIPTION
This renames the `course_banner_slot` to `org.openedx.frontend.learner_dashboard.course_card_banner.v1` in an effort to follow the [ADR in frontend-plugin-framework](https://github.com/openedx/frontend-plugin-framework/blob/master/docs/decisions/0003-slot-naming-and-life-cycle.rst#1-naming-format) that outlines how slots should be named. Since this plugin slot did not exist in the previous Open edX release, this won't be a breaking change. It would be ideal to get this renamed before the next release (Teak). Branches will be cut for Teak next month.