### PR TITLE
fix: unenroll reasons translation

### DIFF
--- a/src/containers/UnenrollConfirmModal/constants.js
+++ b/src/containers/UnenrollConfirmModal/constants.js
@@ -1,5 +1,6 @@
 /* eslint-disable quotes */
 import { StrictDict } from 'utils';
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
 export const reasonKeys = StrictDict({
   prereqs: 'prereqs',
@@ -26,7 +27,7 @@ export const order = [
   reasonKeys.easy,
 ];
 
-const messages = StrictDict({
+const messages = defineMessages({
   [reasonKeys.prereqs]: {
     id: 'learner-dash.unenrollConfirm.reasons.prereqs',
     description: 'Unenroll reason option - missing prerequisites',


### PR DESCRIPTION
The unenroll reasons select wasn't being translated.
This PR fixes the way of messages are being defined, so the [formatjs can detect them](https://formatjs.github.io/docs/react-intl#message-extraction).

To test:

```
tutor mounts add <full-path-to>/frontend-app-learner-dashboard/
tutor dev start -d
make pull_translations
```

Edit one of the supported languages, example "Portuguese Portugal": `src/i18n/messages/frontend-app-learner-dashboard/pt_PT.json` and manually add some translation:
```json
  "learner-dash.unenrollConfirm.reasons.prereqs": "Não tenho os pré-requisitos académicos ou linguísticos",
  "learner-dash.unenrollConfirm.reasons.difficulty": "O material do curso era demasiado difícil",
```

On dashboard choose "Unenroll". 
![image](https://github.com/user-attachments/assets/ca356d19-69ab-4f49-bb0a-8a180c13b35f)

Confirm Unenroll
![image](https://github.com/user-attachments/assets/9b24cfa6-1769-4878-916a-6cb88b889573)

Now 2 of the top reasons are translated!
![image](https://github.com/user-attachments/assets/f4365898-1e21-4a5a-91ad-f8bcf40220fe)
