### PR TITLE
[DO NOT MERGE] testing PR for FPF `idAliases`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .eslintcache
-env.config.*
+# env.config.*
 node_modules
 npm-debug.log
 coverage

--- a/env.config.jsx
+++ b/env.config.jsx
@@ -1,0 +1,36 @@
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const config = {
+  pluginSlots: {
+    course_list_slot: {
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_course_list',
+            type: DIRECT_PLUGIN,
+            RenderWidget: () => (
+              <h1 style={{textAlign: 'center'}}>😀</h1>
+            ),
+          },
+        },
+      ]
+    },
+    course_list_slot_alias: {
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_course_list',
+            type: DIRECT_PLUGIN,
+            RenderWidget: () => (
+              <h1 style={{textAlign: 'center'}}>🥸</h1>
+            ),
+          },
+        },
+      ]
+    }
+  },
+}
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@openedx/frontend-plugin-framework": "^1.6.0",
+        "@openedx/frontend-plugin-framework": "github:brian-smith-tcril/frontend-plugin-framework#f2ef0de",
         "@openedx/frontend-slot-footer": "^1.0.2",
         "@openedx/paragon": "^22.16.0",
         "@redux-devtools/extension": "3.3.0",
@@ -3783,9 +3783,8 @@
       }
     },
     "node_modules/@openedx/frontend-plugin-framework": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-plugin-framework/-/frontend-plugin-framework-1.6.0.tgz",
-      "integrity": "sha512-zgP+/hs/cvcPmFOgVm2xt/qgX1nheNsfipzCO7I3bON4hHyOhmOyzwFZJ7pz7GzCJwKlMVguh3HcJgf4p/BPKQ==",
+      "version": "1.7.0",
+      "resolved": "git+ssh://git@github.com/brian-smith-tcril/frontend-plugin-framework.git#f2ef0de7383f4c8e2436af018182e5f2b5865014",
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@openedx/frontend-plugin-framework": "^1.6.0",
+    "@openedx/frontend-plugin-framework": "github:brian-smith-tcril/frontend-plugin-framework#f2ef0de",
     "@openedx/frontend-slot-footer": "^1.0.2",
     "@openedx/paragon": "^22.16.0",
     "@redux-devtools/extension": "3.3.0",

--- a/src/plugin-slots/CourseListSlot/index.jsx
+++ b/src/plugin-slots/CourseListSlot/index.jsx
@@ -4,7 +4,7 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { CourseList, courseListDataShape } from 'containers/CoursesPanel/CourseList';
 
 export const CourseListSlot = ({ courseListData }) => (
-  <PluginSlot id="course_list_slot" pluginProps={{ courseListData }}>
+  <PluginSlot id="course_list_slot" id_aliases={['course_list_slot_alias']} pluginProps={{ courseListData }}>
     <CourseList courseListData={courseListData} />
   </PluginSlot>
 );


### PR DESCRIPTION
It seems the sandbox won't use a checked-in `env.config.jsx` file. I tried making a testing plugin (https://github.com/brian-smith-tcril/tutor-contrib-fpf-plugin-slot-tester) for tutor (following instructions from https://docs.tutor.edly.io/tutorials/plugin.html, https://github.com/overhangio/cookiecutter-tutor-plugin, and https://github.com/overhangio/tutor-mfe?tab=readme-ov-file#customising-mfes) but hit a few snags.

I don't want making that plugin to block this work, so I have removed the `create-sandbox` label from this PR.

This can still be used as a testing PR, it will just require pulling down this branch locally and running `npm run dev`

> [!NOTE]
> This is using a branch that was made with `dist` checked in before renaming `id_aliases` to `idAliases`. That is why the `PluginSlot` in `CourseListSlot` is using the snake_case form instead of the camelCase form.