### PR TITLE
Audit usage of header elements in Learner Dashboard

### DIFF
--- a/src/containers/CoursesPanel/NoCoursesView/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CoursesPanel/NoCoursesView/__snapshots__/index.test.jsx.snap
@@ -9,9 +9,11 @@ exports[`NoCoursesView snapshot 1`] = `
     alt="No Courses view banner"
     src="icon/mock/path"
   />
-  <h1>
+  <h3
+    className="h1"
+  >
     Looking for a new challenge?
-  </h1>
+  </h3>
   <p>
     Explore our courses to add them to your dashboard.
   </p>

--- a/src/containers/CoursesPanel/NoCoursesView/index.jsx
+++ b/src/containers/CoursesPanel/NoCoursesView/index.jsx
@@ -19,9 +19,9 @@ export const NoCoursesView = () => {
       className="d-flex align-items-center justify-content-center mb-4.5"
     >
       <Image src={emptyCourseSVG} alt={formatMessage(messages.bannerAlt)} />
-      <h1>
+      <h3 className="h1">
         {formatMessage(messages.lookingForChallengePrompt)}
-      </h1>
+      </h3>
       <p>
         {formatMessage(messages.exploreCoursesPrompt)}
       </p>

--- a/src/containers/Dashboard/DashboardLayout.jsx
+++ b/src/containers/Dashboard/DashboardLayout.jsx
@@ -40,8 +40,7 @@ export const DashboardLayout = ({ children }) => {
         <Col {...courseListColumnProps} className="course-list-column">
           {children}
         </Col>
-        <Col {...columnConfig.sidebar} className="sidebar-column">
-          {!isCollapsed && (<h2 className="course-list-title">&nbsp;</h2>)}
+        <Col {...columnConfig.sidebar} className={['sidebar-column', !isCollapsed && 'not-collapsed']}>
           <WidgetSidebarSlot />
         </Col>
       </Row>

--- a/src/containers/Dashboard/DashboardLayout.test.jsx
+++ b/src/containers/Dashboard/DashboardLayout.test.jsx
@@ -84,10 +84,9 @@ describe('DashboardLayout', () => {
 
   describe('not collapsed', () => {
     const testWidgetSpacing = () => {
-      it('shows a blank (nbsp) h2 spacer component above widget sidebar', () => {
+      it('shows not-collapsed class on widget sidebar', () => {
         const columns = el.instance.findByType(Col);
-        // nonbreaking space equivalent
-        expect(columns[1].findByType('h2')[0].children[0].el).toEqual('\xA0');
+        expect(columns[1].props.className).toContain('not-collapsed');
       });
     };
     describe('sidebar showing', () => {

--- a/src/containers/Dashboard/__snapshots__/DashboardLayout.test.jsx.snap
+++ b/src/containers/Dashboard/__snapshots__/DashboardLayout.test.jsx.snap
@@ -24,7 +24,12 @@ exports[`DashboardLayout collapsed sidebar not showing snapshot 1`] = `
       test-children
     </Col>
     <Col
-      className="sidebar-column"
+      className={
+        [
+          "sidebar-column",
+          false,
+        ]
+      }
       lg={
         {
           "offset": 0,
@@ -68,7 +73,12 @@ exports[`DashboardLayout collapsed sidebar showing snapshot 1`] = `
       test-children
     </Col>
     <Col
-      className="sidebar-column"
+      className={
+        [
+          "sidebar-column",
+          false,
+        ]
+      }
       lg={
         {
           "offset": 0,
@@ -112,7 +122,12 @@ exports[`DashboardLayout not collapsed sidebar not showing snapshot 1`] = `
       test-children
     </Col>
     <Col
-      className="sidebar-column"
+      className={
+        [
+          "sidebar-column",
+          "not-collapsed",
+        ]
+      }
       lg={
         {
           "offset": 0,
@@ -126,11 +141,6 @@ exports[`DashboardLayout not collapsed sidebar not showing snapshot 1`] = `
         }
       }
     >
-      <h2
-        className="course-list-title"
-      >
-         
-      </h2>
       <WidgetSidebarSlot />
     </Col>
   </Row>
@@ -161,7 +171,12 @@ exports[`DashboardLayout not collapsed sidebar showing snapshot 1`] = `
       test-children
     </Col>
     <Col
-      className="sidebar-column"
+      className={
+        [
+          "sidebar-column",
+          "not-collapsed",
+        ]
+      }
       lg={
         {
           "offset": 0,
@@ -175,11 +190,6 @@ exports[`DashboardLayout not collapsed sidebar showing snapshot 1`] = `
         }
       }
     >
-      <h2
-        className="course-list-title"
-      >
-         
-      </h2>
       <WidgetSidebarSlot />
     </Col>
   </Row>

--- a/src/containers/Dashboard/index.scss
+++ b/src/containers/Dashboard/index.scss
@@ -6,6 +6,14 @@
 
 .sidebar-column {
   padding: 0 map-get($spacers, 3) 0 map-get($spacers, 1);
+
+  &.not-collapsed {
+    padding-top: map-get($spacers, 2);
+
+    & >:first-child {
+      margin-top: map-get($spacers, 5\.5);
+    }
+  }
 }
 
 @include media-breakpoint-down(lg) {

--- a/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/__snapshots__/index.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/__snapshots__/index.test.jsx.snap
@@ -55,11 +55,11 @@ exports[`ConfirmEmailBanner snapshot Show on unverified 1`] = `
     onClose={[MockFunction closeConfirmModal]}
     title=""
   >
-    <h1
-      className="text-center p-3"
+    <h4
+      className="text-center p-3 h1"
     >
       Confirm your email
-    </h1>
+    </h4>
     <p
       className="text-center"
     >

--- a/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/__snapshots__/index.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/__snapshots__/index.test.jsx.snap
@@ -55,11 +55,11 @@ exports[`ConfirmEmailBanner snapshot Show on unverified 1`] = `
     onClose={[MockFunction closeConfirmModal]}
     title=""
   >
-    <h4
+    <h2
       className="text-center p-3 h1"
     >
       Confirm your email
-    </h4>
+    </h2>
     <p
       className="text-center"
     >

--- a/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
@@ -64,7 +64,7 @@ export const ConfirmEmailBanner = () => {
           </Button>
         )}
       >
-        <h1 className="text-center p-3">{formatMessage(messages.confirmEmailModalHeader)}</h1>
+        <h4 className="text-center p-3 h1">{formatMessage(messages.confirmEmailModalHeader)}</h4>
         <p className="text-center">{formatMessage(messages.confirmEmailModalBody)}</p>
       </MarketingModal>
     </>

--- a/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
@@ -64,7 +64,7 @@ export const ConfirmEmailBanner = () => {
           </Button>
         )}
       >
-        <h4 className="text-center p-3 h1">{formatMessage(messages.confirmEmailModalHeader)}</h4>
+        <h2 className="text-center p-3 h1">{formatMessage(messages.confirmEmailModalHeader)}</h2>
         <p className="text-center">{formatMessage(messages.confirmEmailModalBody)}</p>
       </MarketingModal>
     </>


### PR DESCRIPTION
### Description
As part of this PR we fixed:
- Multiple uses of an h1 tag (Files: NoCoursesView, ConfirmEmailBanner)
- h2 being used as a spacer (Files: DashboardLayout), we added a conditional style replicating h2 spacing

### Screenshots
| Before | After |
| ----- | ----- |
| <img width="1377" alt="Screenshot 2025-05-12 at 4 44 32 p m" src="https://github.com/user-attachments/assets/4cf2e584-9543-44b9-a71e-0968430d6828" /> | <img width="1624" alt="Screenshot 2025-05-16 at 9 36 19 a m" src="https://github.com/user-attachments/assets/d23cc3d2-932c-406f-868f-b5ca070bfa18" /> |
| <img width="1472" alt="Screenshot 2025-05-12 at 4 45 48 p m" src="https://github.com/user-attachments/assets/732eb9f1-5fa0-49d4-ae5e-1e946929db25" /> | <img width="1469" alt="Screenshot 2025-05-12 at 4 30 27 p m" src="https://github.com/user-attachments/assets/98a70922-f489-4a59-91ba-f282d917709c" /> |  |
| <img width="1473" alt="Screenshot 2025-05-12 at 4 43 50 p m" src="https://github.com/user-attachments/assets/de20f3a4-0528-4507-95fa-344f41b7b4ac" /> | <img width="1470" alt="Screenshot 2025-05-12 at 4 34 48 p m" src="https://github.com/user-attachments/assets/44dbceff-695b-429e-b699-378d00fa3c5c" /> |

#### Support Information
This PR fixes #531 
