### PR TITLE
Add advertised start date on course card

### DIFF
--- a/src/containers/CourseCard/components/CourseCardDetails/hooks.js
+++ b/src/containers/CourseCard/components/CourseCardDetails/hooks.js
@@ -10,8 +10,8 @@ export const useAccessMessage = ({ cardId }) => {
   const courseRun = reduxHooks.useCardCourseRunData(cardId);
   const formatDate = utilHooks.useFormatDate();
   if (!courseRun.isStarted) {
-    if (!courseRun.startDate) { return null; }
-    const startDate = formatDate(courseRun.startDate);
+    if (!courseRun.startDate && !courseRun.advertisedStart) { return null; }
+    const startDate = courseRun.advertisedStart ? courseRun.advertisedStart : formatDate(courseRun.startDate);
     return formatMessage(messages.courseStarts, { startDate });
   }
   if (enrollment.isEnrolled) {

--- a/src/data/redux/app/selectors/courseCard.js
+++ b/src/data/redux/app/selectors/courseCard.js
@@ -43,6 +43,7 @@ export const courseCard = StrictDict({
     (courseRun) => (courseRun === null ? {} : {
       endDate: module.loadDateVal(courseRun.endDate),
       startDate: module.loadDateVal(courseRun.startDate),
+      advertisedStart: courseRun.advertisedStart,
 
       courseId: courseRun.courseId,
       isArchived: courseRun.isArchived,

--- a/src/data/redux/app/selectors/courseCard.test.js
+++ b/src/data/redux/app/selectors/courseCard.test.js
@@ -147,6 +147,7 @@ describe('courseCard selectors module', () => {
         loadSelector(courseCard.courseRun, {
           endDate: '3000-10-20',
           startDate: '2000-10-20',
+          advertisedStart: 'Mid June',
 
           courseId: 'test-course-id',
           isArchived: 'test-is-archived',
@@ -171,6 +172,9 @@ describe('courseCard selectors module', () => {
       it('passes [endDate, startDate], converted to dates', () => {
         expect(selected.endDate).toEqual(new Date(testData.endDate));
         expect(selected.startDate).toEqual(new Date(testData.startDate));
+      });
+      it('passes advertised start date', () => {
+        expect(selected.advertisedStart).toEqual(testData.advertisedStart);
       });
       it('passes [courseId, isArchived, isStarted]', () => {
         expect(selected.courseId).toEqual(testData.courseId);


### PR DESCRIPTION
### Description
Currently advertised start date wasn't showing at all on course card or even receiving the value from the endpoints, to accomplish this we had to add that value on the endpoint response and only if a started date was added is showed, if not it falls back to show start date. 

#### Screenshots
Without advertised start date:
<img width="1666" alt="Screenshot 2025-05-15 at 5 40 04 p m" src="https://github.com/user-attachments/assets/d9380a6a-45da-4d6f-9b14-3cad3c400d04" />

With advertised start date:
<img width="1789" alt="Screenshot 2025-05-15 at 5 40 48 p m" src="https://github.com/user-attachments/assets/7f25a272-e300-4616-8848-13ad694d3a05" />

#### Support Information
This PR fixes #558 

#### Related PR
Backend Change: https://github.com/openedx/edx-platform/pull/36726