### PR TITLE
Fix: Updated sign out to logout for consistency

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,7 +80,7 @@ export const App = () => {
       <div>
         <AppWrapper>
           <LearnerDashboardHeader />
-          <main>
+          <main id="main">
             {hasNetworkFailure
               ? (
                 <Alert variant="danger">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,7 +80,7 @@ export const App = () => {
       <div>
         <AppWrapper>
           <LearnerDashboardHeader />
-          <main id="main">
+          <main>
             {hasNetworkFailure
               ? (
                 <Alert variant="danger">

--- a/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
+++ b/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
@@ -65,7 +65,7 @@ const getLearnerHeaderMenu = (
         {
           type: 'item',
           href: `${getConfig().LOGOUT_URL}`,
-          content: formatMessage(messages.signOut),
+          content: formatMessage(messages.logout),
         },
       ],
     },

--- a/src/containers/LearnerDashboardHeader/messages.js
+++ b/src/containers/LearnerDashboardHeader/messages.js
@@ -41,10 +41,10 @@ const messages = defineMessages({
     defaultMessage: 'Order History',
     description: 'The text for the user menu Order History navigation link.',
   },
-  signOut: {
-    id: 'learnerVariantDashboard.menu.signOut.label',
-    defaultMessage: 'Sign Out',
-    description: 'The label for the user menu Sign Out action.',
+  logout: {
+    id: 'learnerVariantDashboard.menu.logout.label',
+    defaultMessage: 'Logout',
+    description: 'The label for the user menu Logout action.',
   },
   course: {
     id: 'learnerVariantDashboard.course',


### PR DESCRIPTION
### 📄 Description
This PR resolves consistency of Inconsistent navigation across "Profile," "Account," and "Dashboard" pages.

## 🎯 Issue
Actual Result:
The "Profile," "Account," and "Dashboard" pages have different navigation lists, leading to inconsistency in the user experience. This inconsistency can confuse users and make navigation between pages less intuitive.
![image](https://github.com/user-attachments/assets/daf75029-fe48-489c-bbec-360ff882f494)


## ✅ Fix
Need to update the word from Sign Out to Logout for consistency among all the pages.

## 🔗 Related
Live Preview: [Demo Course – Progress](https://apps.sandbox.openedx.edly.io/courses/course-v1:edX+DemoX+Demo_Course/progress)
Taiga Ticket: [Inconsistent navigation across "Profile," "Account," and "Dashboard" pages](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/81)
Related GitHub Issue: https://github.com/overhangio/tutor-indigo/issues/146