### PR TITLE
fix: email banner bug

### DIFF
--- a/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import {
   Button,
-  Hyperlink,
   Image,
   MarketingModal,
   ModalDialog,

--- a/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
@@ -26,7 +26,7 @@ export const ConfirmEmailBanner = () => {
   } = useConfirmEmailBannerData();
   const { formatMessage } = useIntl();
 
-  if (!isNeeded) { return null; }
+  // if (!isNeeded) { return null; }
 
   return (
     <>

--- a/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ConfirmEmailBanner/index.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import {
   Button,
+  Hyperlink,
   Image,
   MarketingModal,
   ModalDialog,
@@ -26,7 +27,7 @@ export const ConfirmEmailBanner = () => {
   } = useConfirmEmailBannerData();
   const { formatMessage } = useIntl();
 
-  // if (!isNeeded) { return null; }
+  if (!isNeeded) { return null; }
 
   return (
     <>

--- a/src/data/services/lms/utils.js
+++ b/src/data/services/lms/utils.js
@@ -42,7 +42,7 @@ export const get = (...args) => getAuthenticatedHttpClient().get(...args);
  * @param {string} url - target url
  * @param {object|string} body - post payload
  */
-export const post = (url, body) => getAuthenticatedHttpClient().post(url, stringify(body));
+export const post = (url, body = {}) => getAuthenticatedHttpClient().post(url, stringify(body));
 
 export const client = getAuthenticatedHttpClient;
 


### PR DESCRIPTION
The confirm email banner is currently breaking due to a type error that occurs in the `post` utility function. More details on this can be found in the corresponding issue #627 

To fix, we can pass a default empty object as the body for any POST requests that don't contain a body.