### PR TITLE
feat: add tsconfig.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
 
     - name: Lint
       run: npm run lint
+    
+    - name: Type check
+      run: npm run types
 
     - name: Test
       run: npm run test

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dev": "PUBLIC_PATH=/learner-dashboard/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "TZ=GMT fedx-scripts jest --coverage --passWithNoTests",
     "quality": "npm run lint-fix && npm run test",
-    "watch-tests": "jest --watch"
+    "watch-tests": "jest --watch",
+    "types": "tsc --noEmit"
   },
   "author": "edX",
   "license": "AGPL-3.0",

--- a/src/containers/RelatedProgramsModal/messages.js
+++ b/src/containers/RelatedProgramsModal/messages.js
@@ -10,7 +10,7 @@ const messages = defineMessages({
   description: {
     id: 'learner-dash.relatedPrograms.description',
     description: 'Description for related settings modal',
-    defaultMessage: `Are you looking to expand your knowledge?  Enrolling in a Program lets you take a series of courses in the subject that you're interested in`,
+    defaultMessage: 'Are you looking to expand your knowledge?  Enrolling in a Program lets you take a series of courses in the subject that you\'re interested in',
   },
 });
 

--- a/src/containers/UnenrollConfirmModal/components/messages.js
+++ b/src/containers/UnenrollConfirmModal/components/messages.js
@@ -20,7 +20,7 @@ const messages = defineMessages({
   reasonHeading: {
     id: 'learner-dash.unenrollConfirm.confirm.reason.heading',
     description: 'Heading for unenroll reason modal',
-    defaultMessage: `What's your main reason for unenrolling?`,
+    defaultMessage: 'What\'s your main reason for unenrolling?',
   },
   reasonSkip: {
     id: 'learner-dash.unenrollConfirm.confirm.reason.skip',

--- a/src/containers/UnenrollConfirmModal/constants.js
+++ b/src/containers/UnenrollConfirmModal/constants.js
@@ -31,7 +31,7 @@ const messages = defineMessages({
   [reasonKeys.prereqs]: {
     id: 'learner-dash.unenrollConfirm.reasons.prereqs',
     description: 'Unenroll reason option - missing prerequisites',
-    defaultMessage: `I don't have the academic or language prerequisites`,
+    defaultMessage: 'I don\'t have the academic or language prerequisites',
   },
   [reasonKeys.difficulty]: {
     id: 'learner-dash.unenrollConfirm.reasons.difficulty',
@@ -41,7 +41,7 @@ const messages = defineMessages({
   [reasonKeys.goals]: {
     id: 'learner-dash.unenrollConfirm.reasons.goals',
     description: 'Unenroll reason option - goals-related',
-    defaultMessage: `This won't help me reach my goals`,
+    defaultMessage: 'This won\'t help me reach my goals',
   },
   [reasonKeys.broken]: {
     id: 'learner-dash.unenrollConfirm.reasons.broken',
@@ -51,7 +51,7 @@ const messages = defineMessages({
   [reasonKeys.time]: {
     id: 'learner-dash.unenrollConfirm.reasons.time',
     description: 'Unenroll reason option - time-related',
-    defaultMessage: `I don't have the time`,
+    defaultMessage: 'I don\'t have the time',
   },
   [reasonKeys.browse]: {
     id: 'learner-dash.unenrollConfirm.reasons.browse',
@@ -61,7 +61,7 @@ const messages = defineMessages({
   [reasonKeys.support]: {
     id: 'learner-dash.unenrollConfirm.reasons.support',
     description: 'Unenroll reason option - lacking support',
-    defaultMessage: `I don't have enough support`,
+    defaultMessage: 'I don\'t have enough support',
   },
   [reasonKeys.quality]: {
     id: 'learner-dash.unenrollConfirm.reasons.quality',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@edx/typescript-config",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["*.js", ".eslintrc.js", "dist", "node_modules"]
+}


### PR DESCRIPTION
This will set up for Typescript support as well as resolve [a failing test](https://github.com/openedx/frontend-app-learner-dashboard/actions/runs/17044556788/job/48316804823) that imports `StudioHeader.tsx` from `@edx/frontend-component-header`. I originally modified [the PR](https://github.com/openedx/frontend-app-learner-dashboard/pull/696) itself to add the tsconfig.json file but I feel that this change should be it's own PR instead.

- adds a `tsconfig.json` file to the root of the project
- ran `npm run lint-fix` to change to single quotes for some files
- adds step to workflow to check types