### PR TITLE
fix: Disable Begin Course button if course is closed by prerequisites

### DIFF
--- a/src/containers/CourseCard/components/hooks.js
+++ b/src/containers/CourseCard/components/hooks.js
@@ -3,18 +3,36 @@ import { reduxHooks } from 'hooks';
 export const useActionDisabledState = (cardId) => {
   const { isMasquerading } = reduxHooks.useMasqueradeData();
   const {
-    hasAccess, isAudit, isAuditAccessExpired,
+    hasAccess, isAudit, isAuditAccessExpired, coursewareAccess,
   } = reduxHooks.useCardEnrollmentData(cardId);
+
   const {
     isEntitlement, isFulfilled, canChange, hasSessions,
   } = reduxHooks.useCardEntitlementData(cardId);
 
   const { resumeUrl, homeUrl } = reduxHooks.useCardCourseRunData(cardId);
 
-  const disableBeginCourse = !homeUrl || (isMasquerading || !hasAccess || (isAudit && isAuditAccessExpired));
-  const disableResumeCourse = !resumeUrl || (isMasquerading || !hasAccess || (isAudit && isAuditAccessExpired));
-  const disableViewCourse = !hasAccess || (isAudit && isAuditAccessExpired);
-  const disableSelectSession = !isEntitlement || isMasquerading || !hasAccess || (!canChange || !hasSessions);
+  const blockedByPrereqs = Boolean(coursewareAccess?.hasUnmetPrerequisites);
+
+  const disableBeginCourse = !homeUrl
+    || isMasquerading
+    || !hasAccess
+    || (isAudit && isAuditAccessExpired)
+    || blockedByPrereqs;
+
+  const disableResumeCourse = !resumeUrl
+    || (isMasquerading
+    || !hasAccess
+    || (isAudit && isAuditAccessExpired))
+    || blockedByPrereqs;
+
+  const disableViewCourse = !hasAccess || (isAudit && isAuditAccessExpired) || blockedByPrereqs;
+
+  const disableSelectSession = !isEntitlement
+    || isMasquerading
+    || !hasAccess
+    || (!canChange || !hasSessions)
+    || blockedByPrereqs;
 
   const disableCourseTitle = (isEntitlement && !isFulfilled) || disableViewCourse;
 
@@ -24,6 +42,7 @@ export const useActionDisabledState = (cardId) => {
     disableViewCourse,
     disableSelectSession,
     disableCourseTitle,
+    blockedByPrereqs,
   };
 };
 


### PR DESCRIPTION
Related to this issue - https://github.com/openedx/frontend-app-learner-dashboard/issues/684

**What was done?**

- Added a check for prerequisites (coursewareAccess.hasUnmetPrerequisites) in the useActionDisabledState hook.
- The Begin Course button is now disabled if the course is blocked by unmet prerequisites.
- Similar updates were applied to the Resume Course, View Course, and Select Session buttons so their state also reflects course inaccessibility.
- The logic for disableCourseTitle was updated indirectly through disableViewCourse, so no separate prerequisite check is needed there.

**Why it matters**

Previously, the Begin Course button could remain active even if a course was locked by unmet prerequisites. This misled users: the button was clickable, but access was blocked by the LMS after navigation.

Now, the restriction is surfaced directly in the UI, improving UX and preventing unnecessary transitions.

**Result**

- The Begin Course button (and related actions) correctly reflects course availability.
- Users immediately see when a course is locked by prerequisites.
- Component behavior is now more consistent with the API (coursewareAccess.hasUnmetPrerequisites).

https://github.com/user-attachments/assets/853b0184-976a-42db-ae7d-036634e5d618

