### PR TITLE
Fix frontend component header translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ pull_translations:
       && atlas pull $(ATLAS_OPTIONS) \
                translations/frontend-platform/src/i18n/messages:frontend-platform \
                translations/paragon/src/i18n/messages:paragon \
+               translations/frontend-component-header/src/i18n/messages:frontend-component-header \
                translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
                translations/frontend-app-learner-dashboard/src/i18n/messages:frontend-app-learner-dashboard \
                $(ATLAS_EXTRA_SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ pull_translations:
                translations/frontend-app-learner-dashboard/src/i18n/messages:frontend-app-learner-dashboard \
                $(ATLAS_EXTRA_SOURCES)
 
-	$(intl_imports) frontend-platform paragon frontend-component-footer frontend-app-learner-dashboard $(ATLAS_EXTRA_INTL_IMPORTS)
+	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-app-learner-dashboard $(ATLAS_EXTRA_INTL_IMPORTS)
 
 # This target is used by CI.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
Fix pull_translations in Makefile to include frontend component header translations.

This addresses an issue where translations from plugin slots (such as header_desktop_main_menu.v1) were ignored when modifying the header.

Makefile examples from other MFEs: 

- https://github.com/openedx/frontend-app-learning/blob/bf127d52925c503ac2f4c44c26dfd691b8d75324/Makefile#L33-L45
- https://github.com/openedx/frontend-app-account/blob/166deeafbdff9b3ba415f93a72c5709c83985dbd/Makefile#L44-L55