### PR TITLE
fix: baseAppUrl wrapping links

### DIFF
--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { EXECUTIVE_EDUCATION_COURSE_MODES } from 'data/constants/course';
+import { baseAppUrl } from 'data/services/lms/urls';
 import track from 'tracking';
 import { useCourseTrackingEvent, useCourseData } from 'hooks';
 import { useInitializeLearnerHome } from 'data/hooks';
@@ -26,7 +27,7 @@ export const ResumeButton = ({ cardId }) => {
   const handleClick = useCourseTrackingEvent(
     track.course.enterCourseClicked,
     cardId,
-    resumeUrl + execEdTrackingParam,
+    baseAppUrl(resumeUrl) + execEdTrackingParam,
   );
   return (
     <ActionButton

--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
@@ -6,6 +6,7 @@ import { useCourseTrackingEvent, useCourseData } from 'hooks';
 import track from 'tracking';
 import useActionDisabledState from '../hooks';
 import ResumeButton from './ResumeButton';
+import { baseAppUrl } from 'data/services/lms/urls';
 
 const authOrgId = 'auth-org-id';
 jest.mock('data/hooks', () => ({
@@ -40,7 +41,7 @@ jest.mock('./ActionButton/hooks', () => jest.fn(() => false));
 
 useCourseData.mockReturnValue({
   enrollment: { mode: 'executive-education' },
-  courseRun: { resumeUrl: 'home-url' },
+  courseRun: { resumeUrl: '/resume-url' },
 });
 
 describe('ResumeButton', () => {
@@ -84,7 +85,7 @@ describe('ResumeButton', () => {
         expect(useCourseTrackingEvent).toHaveBeenCalledWith(
           track.course.enterCourseClicked,
           props.cardId,
-          `home-url?org_id=${authOrgId}`,
+          baseAppUrl(`/resume-url?org_id=${authOrgId}`),
         );
       });
     });

--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
@@ -2,11 +2,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { useCourseTrackingEvent, useCourseData } from 'hooks';
+import { baseAppUrl } from 'data/services/lms/urls';
 
 import track from 'tracking';
 import useActionDisabledState from '../hooks';
 import ResumeButton from './ResumeButton';
-import { baseAppUrl } from 'data/services/lms/urls';
 
 const authOrgId = 'auth-org-id';
 jest.mock('data/hooks', () => ({

--- a/src/containers/CourseCard/components/CourseCardBanners/CertificateBanner.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CertificateBanner.jsx
@@ -63,7 +63,7 @@ export const CertificateBanner = ({ cardId }) => {
         {certificate.certPreviewUrl && (
           <>
             {'  '}
-            <Hyperlink isInline destination={certificate.certPreviewUrl}>
+            <Hyperlink isInline destination={baseAppUrl(certificate.certPreviewUrl)}>
               {formatMessage(messages.viewCertificate)}
             </Hyperlink>
           </>


### PR DESCRIPTION
A couple spots that were missed in the React Query conversion. Previously, these links were being wrapped when they were set in Redux state. 

https://github.com/openedx/frontend-app-learner-dashboard/blob/release/ulmo/src/data/redux/app/selectors/courseCard.js#L31

https://github.com/openedx/frontend-app-learner-dashboard/blob/release/ulmo/src/data/redux/app/selectors/courseCard.js#L58

This PR wraps the links in the components where they are used.