### PR TITLE
fix: use actual URLs in course action button hrefs

### DIFF
--- a/src/containers/CourseCard/components/CourseCardActions/BeginCourseButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/BeginCourseButton.jsx
@@ -32,7 +32,7 @@ export const BeginCourseButton = ({ cardId }) => {
     <ActionButton
       disabled={disableBeginCourse}
       as="a"
-      href="#"
+      href={homeUrl + execEdTrackingParam}
       onClick={handleClick}
     >
       {formatMessage(messages.beginCourse)}

--- a/src/containers/CourseCard/components/CourseCardActions/BeginCourseButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/BeginCourseButton.test.jsx
@@ -63,7 +63,7 @@ describe('BeginCourseButton', () => {
       it('should be disabled', () => {
         useActionDisabledState.mockReturnValueOnce({ disableBeginCourse: true });
         renderComponent();
-        const button = screen.getByRole('button', { name: 'Begin Course' });
+        const button = screen.getByRole('link', { name: 'Begin Course' });
         expect(button).toHaveClass('disabled');
         expect(button).toHaveAttribute('aria-disabled', 'true');
       });
@@ -71,14 +71,14 @@ describe('BeginCourseButton', () => {
     describe('enabled', () => {
       it('should be enabled', () => {
         renderComponent();
-        const button = screen.getByRole('button', { name: 'Begin Course' });
+        const button = screen.getByRole('link', { name: 'Begin Course' });
         expect(button).not.toHaveClass('disabled');
         expect(button).not.toHaveAttribute('aria-disabled', 'true');
       });
       it('should track enter course clicked event on click, with exec ed param', () => {
         renderComponent();
         const user = userEvent.setup();
-        const button = screen.getByRole('button', { name: 'Begin Course' });
+        const button = screen.getByRole('link', { name: 'Begin Course' });
         user.click(button);
         expect(useCourseTrackingEvent).toHaveBeenCalledWith(
           track.course.enterCourseClicked,

--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.jsx
@@ -32,7 +32,7 @@ export const ResumeButton = ({ cardId }) => {
     <ActionButton
       disabled={disableResumeCourse}
       as="a"
-      href="#"
+      href={resumeUrl + execEdTrackingParam}
       onClick={handleClick}
     >
       {formatMessage(messages.resume)}

--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
@@ -63,7 +63,7 @@ describe('ResumeButton', () => {
       });
       it('should be disabled', () => {
         render(<IntlProvider locale="en"><ResumeButton {...props} /></IntlProvider>);
-        const button = screen.getByRole('button', { name: 'Resume' });
+        const button = screen.getByRole('link', { name: 'Resume' });
         expect(button).toHaveClass('disabled');
         expect(button).toHaveAttribute('aria-disabled', 'true');
       });
@@ -71,7 +71,7 @@ describe('ResumeButton', () => {
     describe('enabled', () => {
       it('should be enabled', () => {
         render(<IntlProvider locale="en"><ResumeButton {...props} /></IntlProvider>);
-        const button = screen.getByRole('button', { name: 'Resume' });
+        const button = screen.getByRole('link', { name: 'Resume' });
         expect(button).toBeInTheDocument();
         expect(button).not.toHaveClass('disabled');
         expect(button).not.toHaveAttribute('aria-disabled', 'true');
@@ -79,7 +79,7 @@ describe('ResumeButton', () => {
       it('should track enter course clicked event on click, with exec ed param', async () => {
         render(<IntlProvider locale="en"><ResumeButton {...props} /></IntlProvider>);
         const user = userEvent.setup();
-        const button = screen.getByRole('button', { name: 'Resume' });
+        const button = screen.getByRole('link', { name: 'Resume' });
         user.click(button);
         expect(useCourseTrackingEvent).toHaveBeenCalledWith(
           track.course.enterCourseClicked,

--- a/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.jsx
@@ -24,7 +24,7 @@ export const ViewCourseButton = ({ cardId }) => {
     <ActionButton
       disabled={disableViewCourse}
       as="a"
-      href="#"
+      href={homeUrl}
       onClick={handleClick}
     >
       {formatMessage(messages.viewCourse)}

--- a/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.test.jsx
@@ -32,7 +32,7 @@ const homeUrl = 'homeUrl';
 describe('ViewCourseButton', () => {
   it('learner can view course', async () => {
     render(<IntlProvider locale="en"><ViewCourseButton {...defaultProps} /></IntlProvider>);
-    const button = screen.getByRole('button', { name: 'View Course' });
+    const button = screen.getByRole('link', { name: 'View Course' });
     expect(button).toBeInTheDocument();
     expect(button).not.toHaveClass('disabled');
     expect(button).not.toHaveAttribute('aria-disabled', 'true');
@@ -42,7 +42,7 @@ describe('ViewCourseButton', () => {
     useCourseTrackingEvent.mockReturnValue(mockedTrackCourseEvent);
     render(<IntlProvider locale="en"><ViewCourseButton {...defaultProps} /></IntlProvider>);
     const user = userEvent.setup();
-    const button = screen.getByRole('button', { name: 'View Course' });
+    const button = screen.getByRole('link', { name: 'View Course' });
     await user.click(button);
     expect(useCourseTrackingEvent).toHaveBeenCalledWith(
       track.course.enterCourseClicked,
@@ -54,7 +54,7 @@ describe('ViewCourseButton', () => {
   it('learner cannot view course', () => {
     useActionDisabledState.mockReturnValueOnce({ disableViewCourse: true });
     render(<IntlProvider locale="en"><ViewCourseButton {...defaultProps} /></IntlProvider>);
-    const button = screen.getByRole('button', { name: 'View Course' });
+    const button = screen.getByRole('link', { name: 'View Course' });
     expect(button).toHaveClass('disabled');
     expect(button).toHaveAttribute('aria-disabled', 'true');
   });


### PR DESCRIPTION
### Description

Fixes #822.

The `ResumeButton`, `BeginCourseButton`, and `ViewCourseButton` components all rendered their `ActionButton` with `href="#"`, relying entirely on the `useCourseTrackingEvent` click handler for navigation. That handler guards on `courseData?.courseRun?.courseId` before firing, so when that field is missing the tracker never runs, `e.preventDefault()` never executes, and the browser follows `href="#"` - navigating nowhere useful.

This replaces `href="#"` with the actual destination URL in each button. When tracking works, `createLinkTracker` still intercepts the click and navigates after its tracking delay. When it doesn't, the link degrades gracefully to normal anchor behavior.

### LLM usage notice

Built with assistance from Claude.