### PR TITLE
fix: remove learnerDashboardMessages export from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export { default as learnerDashboardApp } from './app';
 export { default as learnerDashboardRoutes } from './routes';
-export { default as learnerDashboardMessages } from './i18n';


### PR DESCRIPTION
The old `App.messages` pattern included apps exporting their messages via `src/index.ts`. There is no reason for apps to export this. The file only exists so the app can run as a site with `npm run dev`. With frontend-base's i18n pipeline, translations are handled at the site level via `site.i18n`.

App-only testing didn't catch this because the webpack fallback plugin correctly resolves the missing messages file when `npm run dev` is running the app as a site from the repo root (`src/i18n/` context). The broken export only surfaces when the compiled `dist/` is consumed by a site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)