### PR TITLE
fix: scope header slot widgets to dashboard role

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
 export const appId = 'org.openedx.frontend.app.learnerDashboard';
+export const dashboardRole = 'org.openedx.frontend.role.dashboard';

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,4 +1,5 @@
 import { authenticatedLoader } from '@openedx/frontend-base';
+import { dashboardRole } from './constants';
 
 const routes = [
   {
@@ -6,7 +7,7 @@ const routes = [
     path: '/learner-dashboard',
     loader: authenticatedLoader,
     handle: {
-      role: 'org.openedx.frontend.role.dashboard'
+      role: dashboardRole
     },
     async lazy () {
       const module = await import('./Main');

--- a/src/widgets/LearnerDashboardHeader/app.tsx
+++ b/src/widgets/LearnerDashboardHeader/app.tsx
@@ -1,6 +1,6 @@
 import { App, LinkMenuItem, WidgetOperationTypes, getAppConfig } from '@openedx/frontend-base';
 
-import { appId } from '../../constants';
+import { appId, dashboardRole } from '../../constants';
 
 import ConfirmEmailBanner from './ConfirmEmailBanner';
 import MasqueradeBar from './MasqueradeBar';
@@ -18,6 +18,9 @@ const app: App = {
       id: 'org.openedx.frontend.widget.learnerDashboard.headerConfirmEmail.v1',
       op: WidgetOperationTypes.PREPEND,
       component: ConfirmEmailBanner,
+      condition: {
+        active: [dashboardRole]
+      }
     },
     {
       slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
@@ -29,7 +32,10 @@ const app: App = {
           url="/"
           variant="navLink"
         />
-      )
+      ),
+      condition: {
+        active: [dashboardRole]
+      }
     },
     {
       slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
@@ -41,6 +47,7 @@ const app: App = {
         />
       ),
       condition: {
+        active: [dashboardRole],
         callback: () => getAppConfig(appId).ENABLE_PROGRAMS === true,
       }
     },
@@ -53,6 +60,9 @@ const app: App = {
           variant="navLink"
         />
       ),
+      condition: {
+        active: [dashboardRole]
+      }
     },
     {
       slotId: 'org.openedx.frontend.slot.header.secondaryLinks.v1',
@@ -64,6 +74,7 @@ const app: App = {
         />
       ),
       condition: {
+        active: [dashboardRole],
         callback: () => getAppConfig(appId).SUPPORT_URL ? true : false,
       }
     },
@@ -78,6 +89,7 @@ const app: App = {
         />
       ),
       condition: {
+        active: [dashboardRole],
         callback: () => getAppConfig(appId).ORDER_HISTORY_URL ? true : false,
       }
     },
@@ -86,6 +98,9 @@ const app: App = {
       id: 'org.openedx.frontend.widget.learnerDashboard.headerMasqueradeBar.v1',
       op: WidgetOperationTypes.APPEND,
       component: MasqueradeBar,
+      condition: {
+        active: [dashboardRole]
+      }
     },
   ]
 };


### PR DESCRIPTION
### Description

Adds an `active: [dashboardRole]` condition to all header slot widget operations so they only render when the dashboard route is active. Previously, none of the slot operations were scoped to the dashboard role, meaning they would appear in the header on every page.

Also extracts the dashboard role string into a shared `dashboardRole` constant in `src/constants.ts`, replacing the hardcoded values in `app.tsx` and `routes.jsx`.

Fixes #829

### LLM usage notice

Built with assistance from Claude.