### PR TITLE
fix: prepend lmsBaseUrl to relative resumeUrl in ResumeButton

### DIFF
--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.jsx
@@ -7,6 +7,7 @@ import { EXECUTIVE_EDUCATION_COURSE_MODES } from '@src/data/constants/course';
 import track from '@src/tracking';
 import { useCourseTrackingEvent, useCourseData } from '@src/hooks';
 import { useInitializeLearnerHome } from '@src/data/hooks';
+import { baseAppUrl } from '@src/data/services/lms/urls';
 import useActionDisabledState from '../hooks';
 import ActionButton from './ActionButton';
 import messages from './messages';
@@ -15,7 +16,7 @@ export const ResumeButton = ({ cardId }) => {
   const { formatMessage } = useIntl();
   const { data: learnerData } = useInitializeLearnerHome();
   const courseData = useCourseData(cardId);
-  const resumeUrl = courseData?.courseRun?.resumeUrl;
+  const resumeUrl = baseAppUrl(courseData?.courseRun?.resumeUrl);
   const execEdTrackingParam = useMemo(() => {
     const isExecEd2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(courseData.enrollment.mode);
     const { authOrgId } = learnerData.enterpriseDashboard || {};

--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
@@ -21,7 +21,7 @@ jest.mock('@src/data/hooks', () => ({
 jest.mock('@src/hooks', () => ({
   useCourseData: jest.fn().mockReturnValue({
     enrollment: { mode: 'executive-education' },
-    courseRun: { homeUrl: 'home-url' },
+    courseRun: { homeUrl: 'http://localhost:8000/courses/course-v1:Test+101+2024/course/' },
   }),
   useCourseTrackingEvent: jest.fn().mockReturnValue({
     trackCourseEvent: jest.fn(),
@@ -40,7 +40,7 @@ jest.mock('./ActionButton/hooks', () => jest.fn(() => false));
 
 useCourseData.mockReturnValue({
   enrollment: { mode: 'executive-education' },
-  courseRun: { resumeUrl: 'home-url' },
+  courseRun: { resumeUrl: '/courses/course-v1:Test+101+2024/courseware/chapter1/' },
 });
 
 describe('ResumeButton', () => {
@@ -84,7 +84,7 @@ describe('ResumeButton', () => {
         expect(useCourseTrackingEvent).toHaveBeenCalledWith(
           track.course.enterCourseClicked,
           props.cardId,
-          `home-url?org_id=${authOrgId}`,
+          `http://localhost:8000/courses/course-v1:Test+101+2024/courseware/chapter1/?org_id=${authOrgId}`,
         );
       });
     });


### PR DESCRIPTION
### Description

When `href="#"` was replaced with actual URLs in the course action buttons (205cc6b37), the ResumeButton's `resumeUrl` lost its `baseAppUrl()` wrapping.

### LLM usage notice

Built with assistance from Claude.