### PR TITLE
feat: header parity updates for learner dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4405,9 +4405,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.23.tgz",
-      "integrity": "sha512-d74micKvGDLZdHkZfI2o1q2hiYzLUSkNuvOs56rFod6PLSa3F4qgrsKE9sa5hAHHMpZdq1q821irbId93QdHTg==",
+      "version": "1.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.26.tgz",
+      "integrity": "sha512-fJPEpLyeCSVDAFVu83kwHQjMEzwCpjbiKD7GRpMZX27bLu9tkNvkssVqxyvZgu/ebAsLN4ga6xTT/34+DLyyZw==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -4422,6 +4422,7 @@
         "@formatjs/ts-transformer": "^3.13.14",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "@stylistic/eslint-plugin": "^2.9.0",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "@types/eslint__js": "^8.42.3",
         "@types/gradient-string": "^1.1.6",
         "@types/lodash.keyby": "^4.6.9",
@@ -5318,9 +5319,20 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.20",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
-      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -5329,19 +5341,37 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.21",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
-      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.90.20"
+        "@tanstack/query-core": "5.99.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
         "react": "^18 || ^19"
       }
     },

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,4 +1,4 @@
-import { authenticatedLoader } from '@openedx/frontend-base';
+import { authenticatedLoader, homeRole } from '@openedx/frontend-base';
 import { dashboardRole } from './constants';
 
 const routes = [
@@ -7,7 +7,7 @@ const routes = [
     path: '/learner-dashboard',
     loader: authenticatedLoader,
     handle: {
-      role: dashboardRole
+      roles: [dashboardRole, homeRole]
     },
     async lazy () {
       const module = await import('./Main');

--- a/src/widgets/LearnerDashboardHeader/MasqueradeBar/index.jsx
+++ b/src/widgets/LearnerDashboardHeader/MasqueradeBar/index.jsx
@@ -3,6 +3,7 @@ import { SiteContext } from '@openedx/frontend-base';
 
 import {
   Chip,
+  Container,
   Form,
   FormControl,
   FormControlFeedback,
@@ -36,8 +37,9 @@ export const MasqueradeBar = () => {
   if (!canMasquerade) { return null; }
 
   return (
-    <div className="w-100 shadow-sm px-2">
-      <Form className="masquerade-bar w-100">
+    <div className="w-100 shadow-sm">
+      <Container fluid size="xl">
+        <Form className="masquerade-bar w-100">
         {isMasquerading ? (
           <>
             <FormLabel inline="true" className="masquerade-form-label">
@@ -85,6 +87,7 @@ export const MasqueradeBar = () => {
           </>
         )}
       </Form>
+      </Container>
     </div>
   );
 };

--- a/src/widgets/LearnerDashboardHeader/MasqueradeBar/index.scss
+++ b/src/widgets/LearnerDashboardHeader/MasqueradeBar/index.scss
@@ -1,11 +1,11 @@
 .masquerade-bar {
   display: flex;
   align-items: flex-start;
-  padding: var(--pgn-spacing-spacer-3);
+  padding: var(--pgn-spacing-spacer-3) 0;
   margin-bottom: var(--pgn-spacing-spacer-2);
 
   .masquerade-form-label {
-    padding: var(--pgn-spacing-spacer-2) var(--pgn-spacing-spacer-3);
+    padding: var(--pgn-spacing-spacer-2) var(--pgn-spacing-spacer-3) var(--pgn-spacing-spacer-2) 0;
     display: flex;
     align-items: center;
     margin-bottom: 0;
@@ -31,6 +31,6 @@
 @media (--pgn-size-breakpoint-max-width-md) {
   .masquerade-bar {
     margin: auto;
-    padding: var(--pgn-spacing-spacer-3) var(--pgn-spacing-spacer-4);
+    padding: var(--pgn-spacing-spacer-3) 0;
   }
 }

--- a/src/widgets/LearnerDashboardHeader/app.tsx
+++ b/src/widgets/LearnerDashboardHeader/app.tsx
@@ -29,7 +29,7 @@ const app: App = {
       element: (
         <LinkMenuItem
           label={<CoursesLink />}
-          url="/"
+          role={dashboardRole}
           variant="navLink"
         />
       ),


### PR DESCRIPTION
### Description

Companion to openedx/frontend-base#225. Updates the learner dashboard to work with the header parity changes in frontend-base.

The dashboard route switches from `handle.role` (string) to `handle.roles` (array) and claims both `dashboardRole` and the new `homeRole`, so the shell logo links back to the dashboard and the `/` redirect works.

The Courses header link now resolves its URL via `dashboardRole` instead of a hardcoded `/`, so it works regardless of the route path and gets properly highlighted as active.

The MasqueradeBar wraps its content in a Paragon `Container fluid size="xl"` so its margins align with the header and main content. The full-width shadow stays on an outer div. Redundant horizontal padding is removed from the bar and its label since the Container handles spacing.

### LLM usage notice

Built with assistance from Claude.