### PR TITLE
fix: let composing site own shell and brand CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/openedx-atlas": "^0.7.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
@@ -2262,13 +2261,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@edx/brand": {
-      "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
-      "license": "GPL-3.0-or-later"
-    },
     "node_modules/@edx/browserslist-config": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.5.1.tgz",
@@ -4405,9 +4397,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.26.tgz",
-      "integrity": "sha512-fJPEpLyeCSVDAFVu83kwHQjMEzwCpjbiKD7GRpMZX27bLu9tkNvkssVqxyvZgu/ebAsLN4ga6xTT/34+DLyyZw==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-eTjdN4tx4zdUA0IgtEKDE4reYsG0ZLsSc62eFXyt1kbHj6UaKEn0WjPotp/2zDLMsk+BcQ7V/LQEVps6FRGK7Q==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -4450,7 +4442,7 @@
         "glob": "^7.2.3",
         "globals": "^15.11.0",
         "gradient-string": "^2.0.2",
-        "html-webpack-plugin": "5.6.0",
+        "html-webpack-plugin": "5.6.7",
         "identity-obj-proxy": "3.0.0",
         "image-minimizer-webpack-plugin": "3.8.3",
         "jest": "^29.7.0",
@@ -11644,9 +11636,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+      "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "url": "git+https://github.com/openedx/frontend-app-learner-dashboard.git"
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./app.scss": "./dist/app.scss"
+    ".": "./dist/index.js"
   },
   "files": [
     "/dist"
@@ -55,7 +54,6 @@
     "url": "https://github.com/openedx/frontend-app-learner-dashboard/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/openedx-atlas": "^0.7.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -2,7 +2,7 @@ import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@o
 
 import { learnerDashboardApp } from './src';
 
-import './src/app.scss';
+import '@openedx/frontend-base/shell/style';
 
 const siteConfig: SiteConfig = {
   siteId: 'learner-dashboard-dev',

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -4,7 +4,7 @@ import { appId } from './constants';
 import ContextProviders from './data/context';
 import Dashboard from './containers/Dashboard';
 
-import './app.scss';
+import './style.scss';
 
 const Main = () => (
   <CurrentAppProvider appId={appId}>

--- a/src/containers/CoursesPanel/index.scss
+++ b/src/containers/CoursesPanel/index.scss
@@ -1,3 +1,5 @@
+@use "@openedx/paragon/styles/css/core/custom-media-breakpoints.css";
+
 .course-list-heading-container {
   display: flex;
   flex-direction: row;

--- a/src/containers/Dashboard/index.scss
+++ b/src/containers/Dashboard/index.scss
@@ -1,3 +1,5 @@
+@use "@openedx/paragon/styles/css/core/custom-media-breakpoints.css";
+
 .course-list-column {
   padding: 0 var(--pgn-spacing-spacer-4);
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -10,7 +10,7 @@ const routes = [
       roles: [dashboardRole, homeRole]
     },
     async lazy () {
-      const module = await import('./Main');
+      const module = await import(/* webpackChunkName: "learner-dashboard-main" */ './Main');
       return { Component: module.default };
     },
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,5 +1,3 @@
-@use "@openedx/frontend-base/shell/app.scss";
-
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";
 

--- a/src/widgets/LearnerDashboardHeader/MasqueradeBar/index.scss
+++ b/src/widgets/LearnerDashboardHeader/MasqueradeBar/index.scss
@@ -1,3 +1,5 @@
+@use "@openedx/paragon/styles/css/core/custom-media-breakpoints.css";
+
 .masquerade-bar {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
### Description

Stops the app from re-bundling the shell stylesheet so lazy-loaded chunks no longer re-declare Paragon's `:root` custom properties and clobber the composing site's brand tokens at runtime. The composing site becomes the single owner of shell, Paragon, and brand CSS.

The dev harness now loads the shell styles via the new JS manifest at `@openedx/frontend-base/shell/style`, imported directly from `site.config.dev.tsx`. The `./app.scss` subpath export is removed, and `@edx/brand` is dropped since the dev harness runs unbranded. App-scoped class rules continue to load per-chunk via `src/style.scss` (renamed from `src/app.scss`), imported from `Main.jsx`.

Mirrors the fix landed in `frontend-app-authn` for the same migration. See openedx/frontend-base#232 for the underlying rationale.

### LLM usage notice

Built with assistance from Claude models (mostly Opus 4.6).