### PR TITLE
fix: set document title via Helmet on the dashboard route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "prop-types": "15.8.1",
+        "react-helmet": "^6.1.0",
         "react-share": "^5.2.2"
       },
       "devDependencies": {
@@ -17567,8 +17568,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-focus-lock": {
       "version": "2.13.7",
@@ -17619,6 +17619,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/react-imask": {
@@ -17924,6 +17939,15 @@
       },
       "peerDependencies": {
         "react": "^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "prop-types": "15.8.1",
+    "react-helmet": "^6.1.0",
     "react-share": "^5.2.2"
   },
   "devDependencies": {

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -1,19 +1,31 @@
-import { CurrentAppProvider, PageWrap } from '@openedx/frontend-base';
+import { CurrentAppProvider, getSiteConfig, PageWrap, useIntl } from '@openedx/frontend-base';
+import { Helmet } from 'react-helmet';
 
 import { appId } from './constants';
 import ContextProviders from './data/context';
 import Dashboard from './containers/Dashboard';
+import messages from './messages';
 
 import './style.scss';
 
-const Main = () => (
-  <CurrentAppProvider appId={appId}>
-    <ContextProviders>
-      <PageWrap>
-        <Dashboard />
-      </PageWrap>
-    </ContextProviders>
-  </CurrentAppProvider>
-);
+const Main = () => {
+  const { formatMessage } = useIntl();
+  return (
+    <CurrentAppProvider appId={appId}>
+      <Helmet>
+        <title>
+          {formatMessage(messages['learner-dash.page.title'], {
+            siteName: getSiteConfig().siteName,
+          })}
+        </title>
+      </Helmet>
+      <ContextProviders>
+        <PageWrap>
+          <Dashboard />
+        </PageWrap>
+      </ContextProviders>
+    </CurrentAppProvider>
+  );
+};
 
 export default Main;

--- a/src/messages.js
+++ b/src/messages.js
@@ -11,6 +11,11 @@ const messages = defineMessages({
     description: 'Page title: Learner Home',
     defaultMessage: 'Learner Home',
   },
+  'learner-dash.page.title': {
+    id: 'learner-dash.page.title',
+    description: 'Document title for the learner dashboard page',
+    defaultMessage: 'Learner Home | {siteName}',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
### Description

Refs openedx/frontend-base#250.

Adopts the per-page document title pattern set out in [frontend-base ADR 0015](https://github.com/openedx/frontend-base/blob/main/docs/decisions/0015-page-titles-via-helmet.rst).  Because all frontend-base apps share a single `index.html`, the document title only changes if a page sets it.  Authn does, but the learner dashboard didn't, so after signing in the browser tab kept reading "Login | <site>" while the user sat on the dashboard.

The dashboard's `Main` route component now renders a `<Helmet>` block that sets `<title>` from a new localized message (`learner-dash.page.title`, default `Learner Home | {siteName}`), with `siteName` pulled from `getSiteConfig()` and passed as an i18n parameter so localizers can re-order the segments.  `react-helmet` is added to the app's runtime dependencies.

### LLM usage notice

Built with assistance from Claude.