### PR TITLE
chore: adopt release-branch model for 1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - frontend-base
+      - release/frontend-base
 
 permissions:
   id-token: write  # Required for OIDC

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,7 @@
 {
   "branches": [
-    "placeholder",
-    { "name": "frontend-base", "prerelease": "alpha", "channel": "latest" }
+    { "name": "release/frontend-base", "channel": "latest" },
+    { "name": "frontend-base", "prerelease": "alpha", "channel": "alpha" }
   ],
   "tagFormat": "v${version}",
   "plugins": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "turbo": "^2.8.20"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "@types/react": "^18",
@@ -4556,9 +4556,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.42.tgz",
-      "integrity": "sha512-3qpoazcIqYc9xqujG/MBs4dNpWGOcGC26+UdTcr5Q2+S08NfEyqg0kUOJTVKh6JjW1F3/RuUGDvrxKtmOWgs2g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.1.tgz",
+      "integrity": "sha512-Xi5D2SqXxTgbGzZRM3F0oSCJkR+6KWnGULAmfw3TQOkmJ43jDIZ0BZ1XrJySScaSXkibG4OZCtcHSjV4IHgm/g==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "turbo": "^2.8.20"
   },
   "peerDependencies": {
-    "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+    "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
     "@openedx/paragon": "^23",
     "@tanstack/react-query": "^5",
     "@types/react": "^18",


### PR DESCRIPTION
### Description

This adopts the release-branch model from ADR 0012 (amended in openedx/frontend-base#274) so that this repo can publish its first stable release, `1.0.0`, to npm `@latest`. Part of openedx/frontend-app-learner-dashboard#851.

Today the rewrite publishes `1.0.0-alpha.*` to `@latest`. The target model is that stable is published from a long-lived `release/frontend-base` branch (npm `@latest`), while the `frontend-base` dev branch publishes `-alpha` prereleases to `@alpha`.

`.releaserc` replaces the `placeholder` entry with the `release/frontend-base` latest-channel entry and sets the `frontend-base` prerelease channel to `alpha` (without it, semantic-release would default the dist-tag to the branch name and land prereleases on `@frontend-base`). `release.yml` now triggers on both `frontend-base` and `release/frontend-base`. The `@openedx/frontend-base` peer dependency is bumped from `^1.0.0-alpha` to `^1.0.0`, the released stable.

The `release/frontend-base` branch has already been cut from the current `frontend-base` tip, so this config can land safely. Once merged, `release/frontend-base` will be fast-forwarded up to `frontend-base` to publish `1.0.0` to `@latest`.

### LLM usage notice

Built with assistance from Claude models (mostly Opus 4.8).
