### PR TITLE
feat!: bundle only real defaults in app config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,14 +130,12 @@ Configuration
 
 This app is no longer configured by build-time environment variables.
 ``getAppConfig`` resolves three sources, in order of increasing precedence: the
-app's bundled defaults, the site's ``commonAppConfig``, and the app's ``config``.
-The first is the app author's, at build time; the other two are the operator's,
-the second applying to every app on the site and the third to this app alone.  In
-edx-platform they arrive as ``MFE_CONFIG`` and
-``MFE_CONFIG_OVERRIDES['learner-dashboard']`` respectively.
+app's bundled ``defaultConfig``, the site's ``commonAppConfig``, and the app's
+``config``.  The first is the app author's, at build time; the other two are the
+operator's, the second applying to every app on the site and the third to this
+app alone.
 
-The full list of keys and their defaults is the ``config`` block in
-``src/app.ts``:
+These are the fields the app reads:
 
 .. list-table::
    :widths: 30 50 20
@@ -147,39 +145,35 @@ The full list of keys and their defaults is the ``config`` block in
      - Description / Usage
      - Example
 
-   * - ``LEARNING_BASE_URL``
-     - Base URL of the Learning MFE, used to build course home and courseware
-       links from the dashboard's cards.
-     - ``http://apps.local.openedx.io:2000``
-
    * - ``ENABLE_PROGRAMS``
      - Shows the Programs link in the header's primary navigation, pointing at
-       the LMS's ``/dashboard/programs``.  The related-programs badges and
-       banners on course cards are driven by course data and are not affected by
-       this.
-     - ``false``
+       the LMS's ``/dashboard/programs``.  The link is hidden when this is
+       unset.  The related-programs badges and banners on course cards are
+       driven by course data and are not affected by this.
+     - ``true``
 
    * - ``ECOMMERCE_BASE_URL``
      - Base URL of the ecommerce service.  Used to build the credit checkout
-       link, as ``ECOMMERCE_BASE_URL/credit/checkout/COURSE_ID/``.
-     - ``''``
+       link, as ``ECOMMERCE_BASE_URL/credit/checkout/COURSE_ID/``.  The credit
+       banner renders no "Get credit" button when neither this nor
+       ``CREDIT_PURCHASE_URL`` is set.
+     - ``http://localhost:18130``
 
    * - ``CREDIT_PURCHASE_URL``
      - Overrides the credit checkout link with ``CREDIT_PURCHASE_URL/COURSE_ID/``,
        for deployments whose credit purchase flow does not live behind
-       ``ECOMMERCE_BASE_URL``.  It has no bundled default; set it to take
-       precedence.
-     - ``''``
+       ``ECOMMERCE_BASE_URL``.  Takes precedence when set.
+     - ``http://credit.example.com``
 
    * - ``ORDER_HISTORY_URL``
      - Destination of the order history link in the header menu.  The link is
-       hidden when this is empty.
-     - ``''``
+       hidden when this is unset.
+     - ``http://localhost:1996/orders``
 
    * - ``SHOW_UNENROLL_SURVEY``
      - Shows the survey that asks learners why they unenrolled, as the last step
-       of the unenrollment flow.
-     - ``false``
+       of the unenrollment flow.  Skipped when unset.
+     - ``true``
 
 *****
 Slots

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "turbo": "^2.8.20"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^2.0.0-alpha.4 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "@types/react": "^18",
@@ -2648,115 +2648,15 @@
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.10.15",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.15.tgz",
-      "integrity": "sha512-i6+xVqT+6KCz7nBfk4ybMXmbKO36tKvbMKtgFz9KV+8idYFyFbfwKooYk8kGjyA5+T5f1kEPQM5IDLXucTAQ9g==",
+      "version": "4.1.19",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.19.tgz",
+      "integrity": "sha512-bZMROATl+rzfL8wsDZ53i8XWHx5e6rVr8QlGT5GDvHImEUro4WE9pxUd2dobzmI3CtD+zkt/wkEdqcb+3CK8Fg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
-      },
-      "peerDependencies": {
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.5.tgz",
-      "integrity": "sha512-85b+GdAKCsleS6cqVxf/Aw/uBd+20EM0wDpgaxzHo3RIR3bxF4xCJqH/Grbzx8CXurTgDDZHPdPdwJC+May41w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.5.tgz",
-      "integrity": "sha512-Wzes10SMNeYgnxYiKsda4rnHP3Q3II4XT2tZyOgnH5fWuHDtIkceuWlRQNsvrI3uiwP4hLqp2XdQTCsfkhXulg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "intl-messageformat": "11.2.14"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
@@ -2769,60 +2669,29 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
     "node_modules/@formatjs/intl/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/@formatjs/ts-transformer": {
       "version": "3.14.2",
@@ -4556,9 +4425,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.1.tgz",
-      "integrity": "sha512-Xi5D2SqXxTgbGzZRM3F0oSCJkR+6KWnGULAmfw3TQOkmJ43jDIZ0BZ1XrJySScaSXkibG4OZCtcHSjV4IHgm/g==",
+      "version": "2.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-2.0.0-alpha.4.tgz",
+      "integrity": "sha512-8cSzRfyKva+cCUpsga4CPpNRN840phB6v17TA8cL4rwa15tUt/d/zAYOoVnznmKPk3voGQbN3cMGkykT6iFFUw==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -4619,7 +4488,7 @@
         "prop-types": "^15.8.1",
         "react-dev-utils": "12.0.1",
         "react-focus-on": "^3.10.2",
-        "react-intl": "^6.6.6",
+        "react-intl": "^10.1.20",
         "react-refresh": "0.18.0",
         "react-refresh-typescript": "^2.0.9",
         "react-responsive": "^10.0.0",
@@ -4648,7 +4517,7 @@
         "openedx": "dist/tools/cli/openedx.js"
       },
       "peerDependencies": {
-        "@openedx/paragon": "^23.20.0",
+        "@openedx/paragon": "^23.23.0",
         "@tanstack/react-query": "^5.81.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4657,9 +4526,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "23.20.0",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.20.0.tgz",
-      "integrity": "sha512-2LOzROn0mkNpeaHjaGMnwgJYIY7CZSHFh7iYq3VB7IViMGo6eD+LboPoY5T48pnYVdDTTgiN3YLTI0h+mt5CwQ==",
+      "version": "23.23.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.23.0.tgz",
+      "integrity": "sha512-dr4zDytE7YC/Hk3sIl3MBgLyeIJBZpPp0tI2x+SQ1d/tJXhyJk4pDOfG8bFbGHt4jaM/cwjwX25jaTUV1jszIg==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [
@@ -4672,17 +4541,16 @@
       "dependencies": {
         "@popperjs/core": "^2.11.4",
         "@tokens-studio/sd-transforms": "^1.2.4",
-        "axios": "^0.30.2",
+        "axios": "^1.0.0",
         "bootstrap": "^4.6.2",
         "chalk": "^4.1.2",
-        "child_process": "^1.0.2",
-        "chroma-js": "^2.4.2",
+        "chroma-js": "^3.0.0",
         "classnames": "^2.3.1",
         "cli-progress": "^3.12.0",
         "commander": "^9.4.1",
         "email-prop-type": "^3.0.0",
         "file-selector": "^0.10.0",
-        "glob": "^8.0.3",
+        "glob": "^13.0.0",
         "inquirer": "^8.2.5",
         "js-toml": "^1.0.0",
         "lodash.uniqby": "^4.7.0",
@@ -4721,70 +4589,52 @@
       "peerDependencies": {
         "react": "^16.8.6 || ^17 || ^18",
         "react-dom": "^16.8.6 || ^17 || ^18",
-        "react-intl": "^5.25.1 || ^6.4.0"
-      }
-    },
-    "node_modules/@openedx/paragon/node_modules/axios": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
-      "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@openedx/paragon/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@openedx/paragon/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
+        "react-intl": "^5.25.1 || ^6.4.0 || ^10.1.20"
       }
     },
     "node_modules/@openedx/paragon/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@openedx/paragon/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
+    "node_modules/@openedx/paragon/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@openedx/paragon/node_modules/postcss-custom-media": {
@@ -5925,19 +5775,6 @@
       "peer": true,
       "dependencies": {
         "@types/tinycolor2": "*"
-      }
-    },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -8100,13 +7937,6 @@
         "lodash-es": "4.17.23"
       }
     },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g==",
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -8124,9 +7954,9 @@
       }
     },
     "node_modules/chroma-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.6.0.tgz",
-      "integrity": "sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
       "license": "(BSD-3-Clause AND Apache-2.0)",
       "peer": true
     },
@@ -11616,23 +11446,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -12250,72 +12063,39 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.7",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.7.tgz",
-      "integrity": "sha512-F134jIoeYMro/3I0h08D0Yt4N9o9pjddU/4IIxMMURqbAtI2wu70X8hvG1V48W49zXHXv3RKSF/po+0fDfsGjA==",
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.14.tgz",
+      "integrity": "sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -17762,87 +17542,37 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
-      "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
+      "version": "10.1.24",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-10.1.24.tgz",
+      "integrity": "sha512-8hiXRnnmOMEPvE5xb1T1Ce1AsmuSWX2voosCsmiyOEGEq83d1mbHy2M1DeoGKt4yF5oPPkzp+aUwSOtf+NYKPA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl": "2.10.15",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "@types/hoist-non-react-statics": "3",
-        "@types/react": "16 || 17 || 18",
-        "hoist-non-react-statics": "3",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "@formatjs/intl": "4.1.19",
+        "intl-messageformat": "11.2.14"
       },
       "peerDependencies": {
-        "react": "^16.6.0 || 17 || 18",
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "turbo": "^2.8.20"
   },
   "peerDependencies": {
-    "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-base": "^2.0.0-alpha.4 || 0.0.0-dev",
     "@openedx/paragon": "^23",
     "@tanstack/react-query": "^5",
     "@types/react": "^18",

--- a/site.config.test.tsx
+++ b/site.config.test.tsx
@@ -17,8 +17,6 @@ const siteConfig: SiteConfig = {
     appId,
     config: {
       ECOMMERCE_BASE_URL: 'http://localhost:18130',
-      FAVICON_URL: 'https://edx-cdn.org/v3/default/favicon.ico',
-      LEARNING_BASE_URL: 'http://localhost:2000',
     },
   }],
 

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,0 +1,20 @@
+import app from './app';
+import { appId } from './constants';
+import routes from './routes';
+import slots from './slots';
+
+describe('learnerDashboardApp', () => {
+  it('declares the learner dashboard appId, routes, and slots', () => {
+    expect(app.appId).toBe(appId);
+    expect(app.routes).toBe(routes);
+    expect(app.slots).toBe(slots);
+  });
+
+  it('bundles no config defaults', () => {
+    expect(app.defaultConfig).toBeUndefined();
+  });
+
+  it('leaves config to the operator', () => {
+    expect(app.config).toBeUndefined();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,13 +9,6 @@ const app: App = {
   routes,
   providers,
   slots,
-  config: {
-    LEARNING_BASE_URL: 'http://apps.local.openedx.io:2000',
-    ENABLE_PROGRAMS: false,
-    ECOMMERCE_BASE_URL: '',
-    ORDER_HISTORY_URL: '',
-    SHOW_UNENROLL_SURVEY: false,
-  }
 };
 
 export default app;

--- a/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/views/EligibleContent.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/views/EligibleContent.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from '@openedx/frontend-base';
 
 import { useCourseData } from '@src/hooks';
+import { creditPurchaseUrl } from '@src/data/services/lms/urls';
 import track from '@src/tracking';
 
 import CreditContent from './components/CreditContent';
@@ -15,6 +16,7 @@ export const EligibleContent = ({ cardId }) => {
   const providerName = courseData?.credit?.providerName;
   const courseId = courseData?.courseRun?.courseId;
 
+  const purchaseUrl = creditPurchaseUrl(courseId);
   const onClick = track.credit.purchase(courseId);
   const getCredit = formatMessage(messages.getCredit);
   const message = providerName
@@ -23,7 +25,7 @@ export const EligibleContent = ({ cardId }) => {
 
   return (
     <CreditContent
-      action={{ onClick, message: getCredit }}
+      action={purchaseUrl ? { onClick, message: getCredit } : null}
       message={message}
     />
   );

--- a/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/views/EligibleContent.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CreditBanner/views/EligibleContent.test.jsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { IntlProvider } from '@openedx/frontend-base';
 
 import { useCourseData } from '@src/hooks';
+import { creditPurchaseUrl } from '@src/data/services/lms/urls';
 import track from '@src/tracking';
 
 import messages from './messages';
@@ -10,6 +11,10 @@ import EligibleContent from './EligibleContent';
 
 jest.mock('@src/hooks', () => ({
   useCourseData: jest.fn(),
+}));
+
+jest.mock('@src/data/services/lms/urls', () => ({
+  creditPurchaseUrl: jest.fn(),
 }));
 
 jest.mock('@src/tracking', () => ({
@@ -24,6 +29,7 @@ const credit = {
   providerName: 'test-credit-provider-name',
 };
 useCourseData.mockReturnValue({ credit, courseRun: { courseId } });
+creditPurchaseUrl.mockReturnValue(`http://ecommerce.example.com/credit/checkout/${courseId}/`);
 
 const renderEligibleContent = () => render(<IntlProvider locale="en" messages={{}}><EligibleContent cardId={cardId} /></IntlProvider>);
 
@@ -53,6 +59,11 @@ describe('EligibleContent component', () => {
         const eligibleMessage = screen.getByTestId('credit-msg');
         expect(eligibleMessage).toBeInTheDocument();
         expect(eligibleMessage).toHaveTextContent(credit.providerName);
+      });
+      it('renders no action when no credit purchase url is configured', () => {
+        creditPurchaseUrl.mockReturnValueOnce(null);
+        renderEligibleContent();
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
       });
       it('message is formatted eligible message if no provider', () => {
         useCourseData.mockReturnValue({ credit: {}, courseRun: { courseId } });

--- a/src/containers/UnenrollConfirmModal/hooks/index.test.js
+++ b/src/containers/UnenrollConfirmModal/hooks/index.test.js
@@ -100,7 +100,7 @@ describe('UnenrollConfirmModal hooks', () => {
       state.restore();
     });
 
-    describe('when SHOW_UNENROLL_SURVEY is true (default)', () => {
+    describe('when the operator sets SHOW_UNENROLL_SURVEY to true', () => {
       beforeEach(() => {
         useAppConfig.mockReturnValue({ SHOW_UNENROLL_SURVEY: true });
       });

--- a/src/data/context/Filters.test.tsx
+++ b/src/data/context/Filters.test.tsx
@@ -646,7 +646,7 @@ describe('FiltersProvider and useFilters', () => {
     });
 
     it('should handle provider re-renders without losing state', () => {
-      const TestWrapper = ({ rerenderTrigger, children }: { rerenderTrigger: number, children: ReactNode }) => (
+      const TestWrapper = ({ rerenderTrigger, children }: { rerenderTrigger: number; children: ReactNode }) => (
         <FiltersProvider>
           <div data-testid={`rerender-${rerenderTrigger}`}>
             {children}

--- a/src/data/context/FiltersProvider.tsx
+++ b/src/data/context/FiltersProvider.tsx
@@ -5,15 +5,15 @@ import React, {
 type SortOption = 'enrolled' | 'title';
 
 interface FiltersContextType {
-  filters: string[],
-  sortBy: SortOption,
-  pageNumber: number,
-  setFilters: (newFilters: string[]) => void,
-  addFilter: (filter: string) => void,
-  removeFilter: (filter: string) => void,
-  clearFilters: () => void,
-  setSortBy: (sortBy: SortOption) => void,
-  setPageNumber: (pageNumber: number) => void,
+  filters: string[];
+  sortBy: SortOption;
+  pageNumber: number;
+  setFilters: (newFilters: string[]) => void;
+  addFilter: (filter: string) => void;
+  removeFilter: (filter: string) => void;
+  clearFilters: () => void;
+  setSortBy: (sortBy: SortOption) => void;
+  setPageNumber: (pageNumber: number) => void;
 }
 
 const FiltersContext = createContext<FiltersContextType | null>(null);

--- a/src/data/context/Masquerade.test.tsx
+++ b/src/data/context/Masquerade.test.tsx
@@ -351,7 +351,7 @@ describe('MasqueradeProvider and useMasquerade', () => {
     });
 
     it('should handle provider re-renders without losing state', () => {
-      const TestWrapper = ({ rerenderTrigger, children }: { rerenderTrigger: number, children: ReactNode }) => (
+      const TestWrapper = ({ rerenderTrigger, children }: { rerenderTrigger: number; children: ReactNode }) => (
         <MasqueradeProvider>
           <div data-testid={`rerender-${rerenderTrigger}`}>
             {children}

--- a/src/data/context/MasqueradeProvider.tsx
+++ b/src/data/context/MasqueradeProvider.tsx
@@ -3,14 +3,14 @@ import React, {
 } from 'react';
 
 interface MasqueradeContextType {
-  masqueradeUser: string | undefined,
-  setMasqueradeUser: (user: string | undefined) => void,
+  masqueradeUser: string | undefined;
+  setMasqueradeUser: (user: string | undefined) => void;
 }
 
 const MasqueradeContext = createContext<MasqueradeContextType | null>(null);
 
 interface MasqueradeProviderProps {
-  children: ReactNode,
+  children: ReactNode;
 }
 
 export const MasqueradeProvider: React.FC<MasqueradeProviderProps> = ({ children }) => {

--- a/src/data/context/SelectSession.test.tsx
+++ b/src/data/context/SelectSession.test.tsx
@@ -379,7 +379,7 @@ describe('SelectSessionModalProvider and useSelectSessionModal', () => {
     });
 
     it('should handle provider re-renders without losing state', () => {
-      const TestWrapper = ({ rerenderTrigger, children }: { rerenderTrigger: number, children: ReactNode }) => (
+      const TestWrapper = ({ rerenderTrigger, children }: { rerenderTrigger: number; children: ReactNode }) => (
         <SelectSessionModalProvider>
           <div data-testid={`rerender-${rerenderTrigger}`}>
             {children}

--- a/src/data/context/SelectSessionProvider.tsx
+++ b/src/data/context/SelectSessionProvider.tsx
@@ -4,23 +4,23 @@ import React, {
 } from 'react';
 
 interface SelectSessionModalState {
-  cardId: string | null,
+  cardId: string | null;
 }
 
 interface SelectSessionModalContextType {
-  selectSessionModal: SelectSessionModalState,
-  updateSelectSessionModal: (cardId: string | null) => void,
-  closeSelectSessionModal: () => void,
+  selectSessionModal: SelectSessionModalState;
+  updateSelectSessionModal: (cardId: string | null) => void;
+  closeSelectSessionModal: () => void;
 }
 
 const SelectSessionModalContext = createContext<SelectSessionModalContextType | null>(null);
 
 interface State {
-  selectSessionModal: SelectSessionModalState,
+  selectSessionModal: SelectSessionModalState;
 }
 
 type Action =
-  | { type: 'UPDATE_SELECT_SESSION_MODAL', payload: string | null }
+  | { type: 'UPDATE_SELECT_SESSION_MODAL'; payload: string | null }
   | { type: 'CLOSE_SELECT_SESSION_MODAL' };
 
 const initialState: State = {
@@ -46,7 +46,7 @@ const selectSessionModalReducer = (state: State, action: Action): State => {
 };
 
 interface SelectSessionModalProviderProps {
-  children: ReactNode,
+  children: ReactNode;
 }
 
 export const SelectSessionModalProvider: React.FC<SelectSessionModalProviderProps> = ({ children }) => {

--- a/src/data/context/index.tsx
+++ b/src/data/context/index.tsx
@@ -4,7 +4,7 @@ import { FiltersProvider, useFilters } from './FiltersProvider';
 import { SelectSessionModalProvider, useSelectSessionModal } from './SelectSessionProvider';
 
 interface ContextProvidersProps {
-  children: ReactNode,
+  children: ReactNode;
 }
 
 const ContextProviders = ({ children }: ContextProvidersProps) => (

--- a/src/data/contexts/GlobalDataContext.tsx
+++ b/src/data/contexts/GlobalDataContext.tsx
@@ -1,19 +1,19 @@
 import { createContext, Dispatch, SetStateAction } from 'react';
 
 interface EmailConfirmation {
-  isNeeded: boolean,
-  sendEmailUrl: string,
+  isNeeded: boolean;
+  sendEmailUrl: string;
 }
 
 interface PlatformSettings {
-  courseSearchUrl: string,
+  courseSearchUrl: string;
 }
 
 interface GlobalDataContextType {
-  emailConfirmation: EmailConfirmation,
-  platformSettings: PlatformSettings,
-  setEmailConfirmation: Dispatch<SetStateAction<EmailConfirmation>> | null,
-  setPlatformSettings: Dispatch<SetStateAction<PlatformSettings>> | null,
+  emailConfirmation: EmailConfirmation;
+  platformSettings: PlatformSettings;
+  setEmailConfirmation: Dispatch<SetStateAction<EmailConfirmation>> | null;
+  setPlatformSettings: Dispatch<SetStateAction<PlatformSettings>> | null;
 }
 
 const GlobalDataContext = createContext<GlobalDataContextType>({

--- a/src/data/hooks/mutationHooks.ts
+++ b/src/data/hooks/mutationHooks.ts
@@ -11,24 +11,24 @@ import {
 import { learnerDashboardQueryKeys, learnerDashboardMutationKeys } from './queryKeys';
 
 interface UpdateEntitlementProps {
-  uuid: string,
-  courseId: string,
+  uuid: string;
+  courseId: string;
 }
 
 interface DeleteEntitlementParams {
-  uuid: string,
-  isRefundable: boolean,
+  uuid: string;
+  isRefundable: boolean;
 }
 
 interface UpdateEmailSettingsParams {
-  courseId: string,
-  enable: boolean,
+  courseId: string;
+  enable: boolean;
 }
 
 interface CreditParams {
-  providerId: string,
-  courseId: string,
-  username: string,
+  providerId: string;
+  courseId: string;
+  username: string;
 }
 
 const useUnenrollFromCourse = () => {

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -18,16 +18,22 @@ const entitlementEnrollment = (uuid) => `${getApiUrl()}/entitlements/v1/entitlem
 export const updateUrl = (base, url) => ((url == null || url.startsWith('http://') || url.startsWith('https://')) ? url : `${base}${url}`);
 
 export const baseAppUrl = (url) => updateUrl(getBaseUrl(), url);
-export const learningMfeUrl = (url) => updateUrl(getAppConfig(appId).LEARNING_BASE_URL, url);
 
 // static view url
 const programsUrl = () => baseAppUrl('/dashboard/programs');
 
+/**
+ * Returns the credit purchase URL for a course, or `null` when the site
+ * configures neither CREDIT_PURCHASE_URL nor ECOMMERCE_BASE_URL.
+ */
 export const creditPurchaseUrl = (courseId) => {
   const config = getAppConfig(appId);
-  return config.CREDIT_PURCHASE_URL
-    ? `${config.CREDIT_PURCHASE_URL}/${courseId}/`
-    : `${config.ECOMMERCE_BASE_URL}/credit/checkout/${courseId}/`;
+  if (config.CREDIT_PURCHASE_URL) {
+    return `${config.CREDIT_PURCHASE_URL}/${courseId}/`;
+  }
+  return config.ECOMMERCE_BASE_URL
+    ? `${config.ECOMMERCE_BASE_URL}/credit/checkout/${courseId}/`
+    : null;
 };
 export const creditRequestUrl = (providerId) => `${getApiUrl()}/credit/v1/providers/${providerId}/request/`;
 
@@ -40,7 +46,6 @@ export default StrictDict({
   entitlementEnrollment,
   event,
   getInitApiUrl,
-  learningMfeUrl,
   programsUrl,
   updateEmailSettings,
 });

--- a/src/data/services/lms/urls.test.js
+++ b/src/data/services/lms/urls.test.js
@@ -3,6 +3,14 @@ import { appId } from '@src/constants';
 import * as urls from './urls';
 
 describe('urls', () => {
+  const config = getAppConfig(appId);
+  const { ECOMMERCE_BASE_URL } = config;
+
+  afterEach(() => {
+    delete config.CREDIT_PURCHASE_URL;
+    config.ECOMMERCE_BASE_URL = ECOMMERCE_BASE_URL;
+  });
+
   describe('baseAppUrl', () => {
     it('returns the url if it is not relative', () => {
       const url = 'http://edx.org';
@@ -18,21 +26,6 @@ describe('urls', () => {
       expect(urls.baseAppUrl(null)).toEqual(null);
     });
   });
-  describe('learningMfeUrl', () => {
-    it('returns the url if it is not relative', () => {
-      const url = 'http://edx.org';
-      expect(urls.learningMfeUrl(url)).toEqual(url);
-    });
-    it('returns the url if it is relative', () => {
-      const url = '/edx.org';
-      expect(urls.learningMfeUrl(url)).toEqual(
-        `${getAppConfig(appId).LEARNING_BASE_URL}${url}`,
-      );
-    });
-    it('return null if url is null', () => {
-      expect(urls.learningMfeUrl(null)).toEqual(null);
-    });
-  });
   describe('creditPurchaseUrl', () => {
     it('builds from ecommerce url and loads courseId', () => {
       const courseId = 'test-course-id';
@@ -41,10 +34,13 @@ describe('urls', () => {
     });
     it('returns CREDIT_PURCHASE_URL if set, with courseId', () => {
       const courseId = 'test-course-id';
-      const config = getAppConfig(appId);
       config.CREDIT_PURCHASE_URL = 'http://credit-purchase.example.com';
       const url = urls.creditPurchaseUrl(courseId);
       expect(url).toBe(`http://credit-purchase.example.com/${courseId}/`);
+    });
+    it('returns null if neither url is configured', () => {
+      delete config.ECOMMERCE_BASE_URL;
+      expect(urls.creditPurchaseUrl('test-course-id')).toBeNull();
     });
   });
   describe('creditRequestUrl', () => {

--- a/src/utils/dataTransformers.test.ts
+++ b/src/utils/dataTransformers.test.ts
@@ -24,10 +24,10 @@ Object.defineProperty(globalThis, 'URLSearchParams', {
 
 interface VisibleListResult {
   visibleList: {
-    course: { courseName: string },
-    enrollment: { lastEnrolled: Date },
-  }[],
-  numPages: number,
+    course: { courseName: string };
+    enrollment: { lastEnrolled: Date };
+  }[];
+  numPages: number;
 }
 
 describe('dataTransformers', () => {
@@ -205,7 +205,7 @@ describe('dataTransformers', () => {
 
     it('should maintain course order', () => {
       interface MockCourseType {
-        course: { courseName: string },
+        course: { courseName: string };
       }
       const result = getTransformedCourseDataList(mockCourses) as MockCourseType[];
 


### PR DESCRIPTION
### Description

Every key an app declares in its own `config` is a key `commonAppConfig` can never supply, since app config is the highest-precedence layer. The learner dashboard declared five, and the audit found none of them to be a genuine default, so `App.defaultConfig` (frontend-base ADR 0017, added by openedx/frontend-base#298) stays empty and the block goes away: `LEARNING_BASE_URL` bundled a laptop URL for `learningMfeUrl`, which nothing calls; `ENABLE_PROGRAMS`, `ORDER_HISTORY_URL` and `SHOW_UNENROLL_SURVEY` were no-ops against already-guarded reads; and `ECOMMERCE_BASE_URL` was an empty-string placeholder that pointed the credit checkout link at the dashboard's own origin, so that button is now gated on a resolved URL. The peer dependency moves to `@openedx/frontend-base` 2.0.0-alpha.4, and the second commit is a mechanical `lint:fix` for a rule frontend-base 2.0 enables. Part of openedx/frontend-base#299, closes #867.

### LLM usage notice

Built with assistance from Claude.