### PR TITLE
build: restore build:packages on turbo 2.10.1+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ npm-install-%: ## install specified % npm package
 	npm install $* --save-dev
 	git add package.json
 
-TURBO = TURBO_TELEMETRY_DISABLED=1 turbo --dangerously-disable-package-manager-check
+TURBO = TURBO_TELEMETRY_DISABLED=1 turbo
 
 NPM_TESTS=build i18n_extract lint test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5498,9 +5498,9 @@
       }
     },
     "node_modules/@turbo/darwin-64": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.3.tgz",
-      "integrity": "sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.12.tgz",
+      "integrity": "sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==",
       "cpu": [
         "x64"
       ],
@@ -5512,9 +5512,9 @@
       ]
     },
     "node_modules/@turbo/darwin-arm64": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.3.tgz",
-      "integrity": "sha512-SIzEkvtNdzdI50FJDaIQ6kQGqgSSdFPcdn0wqmmONN6iGKjy6hsT+EH99GP65FsfV7DLZTh2NmtTIRl2kdoz5Q==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.12.tgz",
+      "integrity": "sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==",
       "cpu": [
         "arm64"
       ],
@@ -5526,9 +5526,9 @@
       ]
     },
     "node_modules/@turbo/linux-64": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.3.tgz",
-      "integrity": "sha512-pLRwFmcHHNBvsCySLS6OFabr/07kDT2pxEt/k6eBf/3asiVQZKJ7Rk88AafQx2aYA641qek4RsXvYO3JYpiBug==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.12.tgz",
+      "integrity": "sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==",
       "cpu": [
         "x64"
       ],
@@ -5536,13 +5536,14 @@
       "license": "MIT",
       "optional": true,
       "os": [
+        "android",
         "linux"
       ]
     },
     "node_modules/@turbo/linux-arm64": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.3.tgz",
-      "integrity": "sha512-gy6ApUroC2Nzv+qjGtE/uPNkhHAFU4c8God+zd5Aiv9L9uBgHlxVJpHT3XWl5xwlJZ2KWuMrlHTaS5kmNB+q1Q==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.12.tgz",
+      "integrity": "sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==",
       "cpu": [
         "arm64"
       ],
@@ -5550,13 +5551,14 @@
       "license": "MIT",
       "optional": true,
       "os": [
+        "android",
         "linux"
       ]
     },
     "node_modules/@turbo/windows-64": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.3.tgz",
-      "integrity": "sha512-d0YelTX6hAsB7kIEtGB3PzIzSfAg3yDoUlHwuwJc3adBXUsyUIs0YLG+1NNtuhcDOUGnWQeKUoJ2pGWvbpRj7w==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.12.tgz",
+      "integrity": "sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==",
       "cpu": [
         "x64"
       ],
@@ -5568,9 +5570,9 @@
       ]
     },
     "node_modules/@turbo/windows-arm64": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.3.tgz",
-      "integrity": "sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.12.tgz",
+      "integrity": "sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==",
       "cpu": [
         "arm64"
       ],
@@ -20805,21 +20807,21 @@
       "peer": true
     },
     "node_modules/turbo": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.3.tgz",
-      "integrity": "sha512-J/VUvsGRykPb9R8Kh8dHVBOqioDexLk9BhLCU/ZybRR+HN9UR3cURdazFvNgMDt9zPP8TF6K73Z+tplfmi0PqQ==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.12.tgz",
+      "integrity": "sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "@turbo/darwin-64": "2.9.3",
-        "@turbo/darwin-arm64": "2.9.3",
-        "@turbo/linux-64": "2.9.3",
-        "@turbo/linux-arm64": "2.9.3",
-        "@turbo/windows-64": "2.9.3",
-        "@turbo/windows-arm64": "2.9.3"
+        "@turbo/darwin-64": "2.10.12",
+        "@turbo/darwin-arm64": "2.10.12",
+        "@turbo/linux-64": "2.10.12",
+        "@turbo/linux-arm64": "2.10.12",
+        "@turbo/windows-64": "2.10.12",
+        "@turbo/windows-arm64": "2.10.12"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openedx/frontend-app-learner-dashboard",
   "version": "0.0.0-dev",
+  "packageManager": "npm@11.12.1",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

`make build-packages` fails on turbo 2.10.1 and later with `package_task_in_single_package_mode`, rejecting the `//#dev:site` root task. turbo 2.10.1 reworked package manager detection, and with no `packageManager` field it falls back to single-package mode, where `//#` root tasks are invalid.

Declaring `packageManager` fixes it. The `--dangerously-disable-package-manager-check` flag was compensating for the missing field and is what now triggers the fallback, so it comes out too. The lockfile bump takes turbo to an affected version, where this is verified.

Part of openedx/frontend-base#312.

### LLM usage notice

Built with assistance from Claude.
